### PR TITLE
RANCHER-2962. Triage mvn version error as an infrastructure error

### DIFF
--- a/.github/actions/collect-app-version/README.md
+++ b/.github/actions/collect-app-version/README.md
@@ -87,22 +87,36 @@ jobs:
 
 ## Inputs
 
-| Input      | Description                                               | Required  | Default                          |
-|------------|-----------------------------------------------------------|-----------|----------------------------------|
-| `app_name` | Full repository path (e.g., `folio-org/app-platform`)     | ✅         | \-                               |
-| `branch`   | Branch name to collect version from                       | ✅         | \-                               |
-| `token`    | GitHub token with repository read permissions             | ❌         | `${{ github.token }}` if not set |
+| Input           | Description                                                                              | Required | Default                          |
+|-----------------|------------------------------------------------------------------------------------------|----------|----------------------------------|
+| `app_name`      | Full repository path (e.g., `folio-org/app-platform`)                                    | ✅       | \-                               |
+| `branch`        | Branch name to collect version from                                                      | ✅       | \-                               |
+| `token`         | GitHub token with repository read permissions                                            | ❌       | `${{ github.token }}` if not set |
+| `skip_checkout` | Skip the internal `actions/checkout` when the caller already has the repo in workspace   | ❌       | `'false'`                        |
 
 ## Outputs
 
-| Output         | Description                          | Example             |
-|----------------|--------------------------------------|---------------------|
-| `version`      | Complete version string from pom.xml | `1.2.3-SNAPSHOT.45` |
-| `major`        | Major version number                 | `1`                 |
-| `minor`        | Minor version number                 | `2`                 |
-| `patch`        | Patch version number                 | `3`                 |
-| `is_snapshot`  | Whether this is a SNAPSHOT version   | `true` or `false`   |
-| `build_number` | Build number (for SNAPSHOT versions) | `45`                |
+| Output                    | Description                                                                            | Example             |
+|---------------------------|----------------------------------------------------------------------------------------|---------------------|
+| `version`                 | Complete version string from pom.xml                                                   | `1.2.3-SNAPSHOT.45` |
+| `major`                   | Major version number                                                                   | `1`                 |
+| `minor`                   | Minor version number                                                                   | `2`                 |
+| `patch`                   | Patch version number                                                                   | `3`                 |
+| `is_snapshot`             | Whether this is a SNAPSHOT version                                                     | `true` or `false`   |
+| `build_number`            | Build number (for SNAPSHOT versions)                                                   | `45`                |
+| `is_infrastructure_error` | `true` only when `mvn` itself failed (treat as transient); `false` on success or app-level failures | `true` or `false`   |
+| `error_category`          | `NONE` \| `INFRASTRUCTURE` \| `POM_NOT_FOUND` \| `INVALID_VERSION_FORMAT`              | `NONE`              |
+| `failure_reason`          | Standard failure message when the read failed (empty on success)                       | `Failed to read application version via mvn` |
+
+The action always exits 1 on any failure, but classifies the cause so callers can route notifications differently:
+
+| Failure                                     | Exit | `is_infrastructure_error` | `error_category`         |
+|---------------------------------------------|------|---------------------------|--------------------------|
+| `pom.xml` not found in workspace            | 1    | `false`                   | `POM_NOT_FOUND`          |
+| `mvn` exit non-zero (likely transient)      | 1    | `true`                    | `INFRASTRUCTURE`         |
+| Version doesn't match `X.Y.Z[-SNAPSHOT[.N]]`| 1    | `false`                   | `INVALID_VERSION_FORMAT` |
+
+Callers that suppress noisy team-channel notifications on transient failures (see `application-update-flow.yml`) should gate on `is_infrastructure_error == 'true'` only — the two app-level categories should still surface to the team because they indicate real configuration/setup bugs.
 
 ## Version Format Support
 

--- a/.github/actions/collect-app-version/action.yml
+++ b/.github/actions/collect-app-version/action.yml
@@ -10,6 +10,10 @@ inputs:
   token:
     description: 'GitHub token with organization read permissions'
     required: false
+  skip_checkout:
+    description: 'Skip checkout when caller already has the repo in the workspace'
+    required: false
+    default: 'false'
 
 outputs:
   version:
@@ -30,15 +34,25 @@ outputs:
   build_number:
     description: 'Build number'
     value: ${{ steps.collect-version.outputs.build_number }}
+  is_infrastructure_error:
+    description: 'true only when mvn itself failed (treat as transient)'
+    value: ${{ steps.collect-version.outputs.is_infrastructure_error }}
+  error_category:
+    description: 'NONE | INFRASTRUCTURE (mvn failure) | POM_NOT_FOUND | INVALID_VERSION_FORMAT'
+    value: ${{ steps.collect-version.outputs.error_category }}
+  failure_reason:
+    description: 'Standard failure message if the read failed'
+    value: ${{ steps.collect-version.outputs.failure_reason }}
 
 runs:
   using: 'composite'
   steps:
     - name: Checkout branch
+      if: inputs.skip_checkout != 'true'
       uses: actions/checkout@v4
       with:
         token: ${{ inputs.token || github.token }}
-        repository: ${{ inputs.app_name }}          
+        repository: ${{ inputs.app_name }}
         ref: ${{ inputs.branch }}
         fetch-depth: 0
 
@@ -48,33 +62,60 @@ runs:
       run: |
         set -eo pipefail
 
-        test -f pom.xml || { echo "::error::pom.xml not found in repository"; exit 1; }
+        fail_infra() {
+          local msg="$1"
+          echo "::error::$msg (classified as INFRASTRUCTURE)"
+          {
+            echo "is_infrastructure_error=true"
+            echo "error_category=INFRASTRUCTURE"
+            echo "failure_reason=$msg"
+          } >> "$GITHUB_OUTPUT"
+          exit 1
+        }
 
-        current_version=$(mvn -q \
+        fail_app() {
+          local category="$1"
+          local msg="$2"
+          echo "::error::$msg"
+          {
+            echo "is_infrastructure_error=false"
+            echo "error_category=$category"
+            echo "failure_reason=$msg"
+          } >> "$GITHUB_OUTPUT"
+          exit 1
+        }
+
+        test -f pom.xml || fail_app "POM_NOT_FOUND" "pom.xml not found in repository"
+
+        if ! current_version=$(mvn -B -ntp -q \
                     -Dexec.executable=echo \
                     -Dexec.args='${project.version}' \
                     --non-recursive exec:exec \
-                    -f pom.xml \
-                    || echo unknown)
+                    -f pom.xml); then
+          fail_infra "Failed to read application version via mvn"
+        fi
 
-        echo "::notice::Current version from previous release branch: $current_version"
+        echo "::notice::Current version from pom.xml: $current_version"
 
         if [[ ! $current_version =~ ^[0-9]+\.[0-9]+\.[0-9]+(-SNAPSHOT(\.[0-9]+)?)?$ ]]; then
-          echo "::error::Unable to parse version from pom.xml: $current_version"
-          exit 1
+          fail_app "INVALID_VERSION_FORMAT" "Unable to parse version from pom.xml: $current_version"
         fi
 
         IFS='.- ' read -r major minor patch snapshot build <<<"${current_version//-SNAPSHOT/- SNAPSHOT}"
-          
+
         echo "::notice::Major version: $major"
         echo "::notice::Minor version: $minor"
         echo "::notice::Patch version: $patch"
         echo "::notice::Snapshot version: $snapshot"
         echo "::notice::Build number: $build"
 
-        echo "version=$current_version" >> "$GITHUB_OUTPUT"
-        echo "major=$major" >> "$GITHUB_OUTPUT"
-        echo "minor=$minor" >> "$GITHUB_OUTPUT"
-        echo "patch=$patch" >> "$GITHUB_OUTPUT"
-        echo "is_snapshot=$([ "$snapshot" = "SNAPSHOT" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
-        echo "build_number=$build" >> "$GITHUB_OUTPUT"
+        {
+          echo "version=$current_version"
+          echo "major=$major"
+          echo "minor=$minor"
+          echo "patch=$patch"
+          echo "is_snapshot=$([ "$snapshot" = "SNAPSHOT" ] && echo true || echo false)"
+          echo "build_number=$build"
+          echo "is_infrastructure_error=false"
+          echo "error_category=NONE"
+        } >> "$GITHUB_OUTPUT"

--- a/.github/docs/application-update-flow.md
+++ b/.github/docs/application-update-flow.md
@@ -42,9 +42,9 @@ This workflow implements the core update flow for FOLIO applications. It coordin
 | `updated_modules`         | List of updated modules                                                   |
 | `pr_created`              | Whether a PR was created                                                  |
 | `pr_url`                  | URL of created/updated PR                                                 |
-| `failure_reason`          | Reason for failure (validation or publishing errors)                      |
+| `failure_reason`          | Reason for failure (version read, version bump, validation, or publishing errors) |
 | `commit_sha`              | Commit SHA                                                                |
-| `error_category`          | Error classification (`NONE`, `INFRASTRUCTURE`, `MODULE_NOT_FOUND`, etc.) |
+| `error_category`          | Error classification (`NONE`, `INFRASTRUCTURE`, `POM_NOT_FOUND`, `INVALID_VERSION_FORMAT`, `MODULE_NOT_FOUND`, ...) |
 | `is_infrastructure_error` | Whether error is infrastructure-related (`true`/`false`)                  |
 | `dependency_validation_bypassed` | Whether dependency validation failure was bypassed                   |
 | `bypass_warning`          | Warning message with error details when validation was bypassed           |
@@ -80,6 +80,8 @@ Determines the source branch and checks for existing PRs:
 Uses the `generate-application-descriptor` action with `generation_mode: update`:
 
 **Process**:
+- Reads current pom version via the `collect-app-version` action (`skip_checkout: true`); failures are classified as `INFRASTRUCTURE` (transient mvn) or `INVALID_VERSION_FORMAT` / `POM_NOT_FOUND` (application-level)
+- Increments patch version and runs `mvn versions:set` (PR-mode runs only); `mvn` failures here are classified as `INFRASTRUCTURE`
 - Resolves version constraints from `application.template.json` (^2.0.0 → 2.3.1)
 - Full module synchronization (add/remove/upgrade/downgrade)
 - Validates Docker images and NPM packages exist
@@ -215,6 +217,8 @@ NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}-SNAPSHOT.${BUILD_NUMBER}"
 NEW_PATCH=$((PATCH + 1))
 NEW_VERSION="${MAJOR}.${MINOR}.${NEW_PATCH}"
 ```
+
+> The increment is performed by `mvn versions:set` after reading current `major`/`minor`/`patch` from the [`collect-app-version`](../actions/collect-app-version/README.md) action's outputs.
 
 ## 🛡️ Validation and Quality Assurance
 
@@ -481,6 +485,6 @@ Solution: Check repository permissions and GitHub API status
 
 ---
 
-**Last Updated**: March 2026
-**Workflow Version**: 3.0 (Validation Skip + Publish/Release Controls + Manual Dispatch)
+**Last Updated**: May 2026
+**Workflow Version**: 3.1 (Reuse `collect-app-version` action + Infrastructure Error Classification for Version Bump)
 **Compatibility**: All FOLIO application repositories

--- a/.github/docs/release-preparation-flow.md
+++ b/.github/docs/release-preparation-flow.md
@@ -51,12 +51,13 @@ All commits use the reusable **`commit-and-push-changes.yml`** workflow for cons
 
 ### Outputs
 
-| Output          | Description                                      |
-|-----------------|--------------------------------------------------|
-| `app_name`      | Application name (pass-through from input)       |
-| `app_version`   | Determined application version for release       |
-| `source_branch` | Source branch used for release preparation       |
-| `commit_sha`    | SHA of the commit on the new release branch      |
+| Output           | Description                                      |
+|------------------|--------------------------------------------------|
+| `app_name`       | Application name (pass-through from input)       |
+| `app_version`    | Determined application version for release       |
+| `source_branch`  | Source branch used for release preparation       |
+| `commit_sha`     | SHA of the commit on the new release branch      |
+| `failure_reason` | Specific reason for failure if any               |
 
 ## 🔄 Workflow Execution Flow
 
@@ -71,9 +72,10 @@ All commits use the reusable **`commit-and-push-changes.yml`** workflow for cons
    - Detects default branch using GitHub API: `gh api repos/{repo} --jq .default_branch`
 
 2. **Version Determination**
-   - Collects version from source branch (previous release or snapshot)
-   - Calculates new release version (typically major version increment)
-   - Handles snapshot version logic if enabled
+   - Reads current version from source branch via the [`collect-app-version`](../actions/collect-app-version/README.md) action
+   - Optionally reads default-branch version (snapshot fallback case) via the same action
+   - Calculates new release version (typically major version increment, or minor bump for snapshot fallback)
+   - If the action fails (mvn error, missing pom, unparseable version), the actual `failure_reason` from the action propagates through the job's `failure_reason` output instead of the generic `"Template update or branch verification failed"` fallback
 
 3. **Template Update**
    - Updates `application.template.json`:
@@ -546,11 +548,12 @@ new_patch=0
 - **[Release Preparation (Public Wrapper)](release-preparation.md)**: Public wrapper with notifications
 - **[Distributed Orchestration](distributed-orchestration.md)**: Cross-repository coordination
 - **[Commit and Push Changes](commit-and-push-changes.md)**: Reusable commit workflow
+- **[Collect Application Version Action](../actions/collect-app-version/README.md)**: Reads version from pom.xml; classifies failures as `INFRASTRUCTURE` / `POM_NOT_FOUND` / `INVALID_VERSION_FORMAT`
 - **[Security Implementation](security-implementation.md)**: Authorization patterns
 - **[FOLIO Release Process](https://folio-org.atlassian.net/wiki/spaces/FOLIJET/pages/886178625/Release+preparation)**: Official documentation
 
 ---
 
-**Last Updated**: October 2025
-**Workflow Version**: 1.0 (Flow extraction)
+**Last Updated**: May 2026
+**Workflow Version**: 1.1 (Propagate `failure_reason` from `collect-app-version` action through job-level output)
 **Compatibility**: All FOLIO application repositories with application.template.json

--- a/.github/workflows/application-update-flow.yml
+++ b/.github/workflows/application-update-flow.yml
@@ -279,9 +279,9 @@ jobs:
       app_descriptor_file_name: ${{ steps.generate.outputs.descriptor_file_name }}
       artifact_name: ${{ steps.generate.outputs.artifact_name }}
       state_file_artifact_name: ${{ steps.upload-state.outputs.artifact_name }}
-      failure_reason: ${{ steps.bump-version.outputs.failure_reason || steps.generate.outputs.failure_reason || '' }}
-      error_category: ${{ steps.bump-version.outputs.error_category || steps.generate.outputs.error_category }}
-      is_infrastructure_error: ${{ (steps.bump-version.outputs.is_infrastructure_error == 'true' || steps.generate.outputs.is_infrastructure_error == 'true') && 'true' || 'false' }}
+      failure_reason: ${{ steps.current-version.outputs.failure_reason || steps.bump-version.outputs.failure_reason || steps.generate.outputs.failure_reason || '' }}
+      error_category: ${{ steps.current-version.outputs.error_category || steps.bump-version.outputs.error_category || steps.generate.outputs.error_category }}
+      is_infrastructure_error: ${{ (steps.current-version.outputs.is_infrastructure_error == 'true' || steps.bump-version.outputs.is_infrastructure_error == 'true' || steps.generate.outputs.is_infrastructure_error == 'true') && 'true' || 'false' }}
     steps:
       - name: Checkout Application Repository
         uses: actions/checkout@v4
@@ -330,6 +330,19 @@ jobs:
             echo "value=$RUN_NUMBER" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Collect Current Version
+        id: current-version
+        if: |
+          needs.prepare-context.outputs.need_pr == 'true' &&
+          needs.prepare-context.outputs.pr_exists != 'true' &&
+          needs.prepare-context.outputs.update_branch_exists != 'true'
+        uses: folio-org/kitfox-github/.github/actions/collect-app-version@master
+        with:
+          skip_checkout: 'true'
+          app_name: ${{ inputs.repo }}
+          branch: ${{ needs.prepare-context.outputs.target_branch }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Increment Application Patch Version
         id: bump-version
         if: |
@@ -337,6 +350,12 @@ jobs:
           needs.prepare-context.outputs.pr_exists != 'true' &&
           needs.prepare-context.outputs.update_branch_exists != 'true'
         shell: bash
+        env:
+          CURRENT_VERSION: ${{ steps.current-version.outputs.version }}
+          MAJOR: ${{ steps.current-version.outputs.major }}
+          MINOR: ${{ steps.current-version.outputs.minor }}
+          PATCH: ${{ steps.current-version.outputs.patch }}
+          IS_SNAPSHOT: ${{ steps.current-version.outputs.is_snapshot }}
         run: |
           set -euo pipefail
 
@@ -346,66 +365,28 @@ jobs:
             exit 0
           fi
 
-          fail_infra() {
-            local phase="$1"
-            local log_file="$2"
-            echo "::endgroup::" || true
-            sync || true
-            local err=""
-            if [[ -s "$log_file" ]]; then
-              err=$({ grep -E "(ERROR|FAILURE|Exception)" "$log_file" 2>/dev/null || true; } | head -3 | tr '\n' ' ')
-            fi
-            echo "::error::Maven $phase failed (classified as INFRASTRUCTURE): ${err:-see log above}"
+          suffix=""
+          [[ "$IS_SNAPSHOT" == "true" ]] && suffix="-SNAPSHOT"
+          new_version="${MAJOR}.${MINOR}.$((PATCH + 1))${suffix}"
+
+          echo "::group::Updating pom.xml version"
+          if ! mvn -B -ntp -q versions:set -DnewVersion="$new_version" -DgenerateBackupPoms=false; then
+            echo "::endgroup::"
+            echo "::error::Maven versions:set failed (classified as INFRASTRUCTURE)"
             {
               echo "is_infrastructure_error=true"
               echo "error_category=INFRASTRUCTURE"
-              echo "failure_reason=Maven $phase failed during version bump: ${err:-no output captured}"
+              echo "failure_reason=Maven versions:set failed during version bump"
               echo "bumped=false"
             } >> "$GITHUB_OUTPUT"
-            rm -f "$log_file"
-            exit 1
-          }
-
-          echo "::group::Reading current pom.xml version"
-          eval_stdout=$(mktemp)
-          eval_log=$(mktemp)
-          if ! mvn -B -ntp -q -DforceStdout help:evaluate -Dexpression=project.version >"$eval_stdout" 2>"$eval_log"; then
-            cat "$eval_log" >&2 || true
-            rm -f "$eval_stdout"
-            fail_infra "help:evaluate" "$eval_log"
-          fi
-          current=$(tr -d '[:space:]' <"$eval_stdout")
-          echo "Current version: $current"
-          rm -f "$eval_stdout" "$eval_log"
-          echo "::endgroup::"
-
-          if [[ "$current" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(.*)$ ]]; then
-            major="${BASH_REMATCH[1]}"
-            minor="${BASH_REMATCH[2]}"
-            patch="${BASH_REMATCH[3]}"
-            rest="${BASH_REMATCH[4]}"   # includes any suffix like -SNAPSHOT, -RC1, +build, etc.
-          else
-            sanitized="${current//$'\n'/ }"
-            echo "::error::Unsupported version format (expected X.Y.Z...): $sanitized"
-            echo "failure_reason=Unsupported pom version format: $sanitized" >> "$GITHUB_OUTPUT"
-            echo "bumped=false" >> "$GITHUB_OUTPUT"
             exit 1
           fi
-
-          new_version="${major}.${minor}.$((patch + 1))${rest}"
-
-          echo "::group::Updating pom.xml version"
-          set_log=$(mktemp)
-          if ! mvn -B -ntp -q versions:set -DnewVersion="$new_version" -DgenerateBackupPoms=false 2>&1 | tee "$set_log"; then
-            fail_infra "versions:set" "$set_log"
-          fi
-          rm -f "$set_log"
           echo "::endgroup::"
 
-          echo "::notice::Version bumped: $current -> $new_version"
+          echo "::notice::Version bumped: $CURRENT_VERSION -> $new_version"
           {
             echo "bumped=true"
-            echo "old_version=$current"
+            echo "old_version=$CURRENT_VERSION"
             echo "new_version=$new_version"
           } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/release-preparation-flow.yml
+++ b/.github/workflows/release-preparation-flow.yml
@@ -85,7 +85,13 @@ jobs:
       app_version: ${{ steps.determine-new-version.outputs.new_version }}
       source_branch: ${{ steps.verify-branches.outputs.source_branch }}
       default_branch: ${{ steps.verify-branches.outputs.default_branch }}
-      failure_reason: ${{ steps.verify-branches.outputs.error || steps.update-template.outputs.error }}
+      failure_reason: >-
+        ${{
+          steps.verify-branches.outputs.error ||
+          steps.collect-previous-version.outputs.failure_reason ||
+          steps.collect-default-branch-version.outputs.failure_reason ||
+          steps.update-template.outputs.error
+        }}
 
     env:
       PREV_BRANCH: ${{ inputs.previous_release_branch }}


### PR DESCRIPTION
## Summary

Classifies transient `mvn` failures during the application-update version bump as infrastructure errors so they stop paging the team Slack channel, and simplifies the bump implementation by reusing the existing `collect-app-version` action instead of a bespoke `mvn help:evaluate` + log-parsing path.

Refs [RANCHER-2962](https://folio-org.atlassian.net/browse/RANCHER-2962)

## Motivation

Scheduled `application-update-flow` runs occasionally fail at the `Increment Application Patch Version` step on transient Maven Central / plugin-download issues. Example: [app-serials-management run 25276135240](https://github.com/folio-org/app-serials-management/actions/runs/25276135240) — `mvn help:evaluate` exited 1 after ~5s with an empty log on `R1-2026` while `snapshot` succeeded seconds later in the same scheduled run.

These transient failures were classified as application errors and routed to the team Slack channel (`SLACK_NOTIF_CHANNEL`). Because the `application-update` workflow runs many times a day across the entire `app-*` fleet, the noise was significant.

The team-channel suppression mechanism (`is_infrastructure_error`, gated at `application-update.yml:354`) already existed for failures inside `generate-application-descriptor`. This PR extends the same classification to the earlier version-read and version-bump steps.

A second iteration during review revealed the bespoke read+parse code was reinventing what `collect-app-version` already does. This PR reuses that action for the read and reduces the bump step to "set or fail with a standard message" — no log parsing.

## Changes

### `collect-app-version` action — additive enhancements

- **New input** `skip_checkout` (default `'false'`) — lets callers that already have the repo checked out skip the action's internal `actions/checkout`. Existing callers don't pass it; behavior preserved.
- **New outputs** `is_infrastructure_error`, `error_category`, `failure_reason` — for downstream notification routing.
- **Failure classification split** into two helpers:
  - `mvn` exit non-zero → `error_category=INFRASTRUCTURE`, `is_infrastructure_error=true` (transient).
  - `pom.xml` missing → `error_category=POM_NOT_FOUND`, `is_infrastructure_error=false` (app-config issue).
  - Version regex mismatch → `error_category=INVALID_VERSION_FORMAT`, `is_infrastructure_error=false` (app-config issue, e.g. someone commits `1.0.0-RC1`).
- **Dropped** the `|| echo unknown` fallback that masked genuine `mvn` failures.

### `application-update-flow.yml` — bump-version simplified

- **Removed** ~80 lines of bespoke `mvn help:evaluate` + log capture + ERROR-line grep + length caps + empty-output guards.
- **Added** a `Collect Current Version` step calling `collect-app-version@master` with `skip_checkout: 'true'`.
- **Rewrote** `Increment Application Patch Version` to ~30 lines that consume the action's parsed outputs (`major`/`minor`/`patch`/`is_snapshot`), compute the new version, and run `mvn versions:set`. On failure → standard infra-error block + exit 1.
- **Extended** the `update-application` job-level `failure_reason` / `error_category` / `is_infrastructure_error` outputs to OR across `current-version`, `bump-version`, and `generate` steps. The existing team-channel suppression at `application-update.yml:354` picks up these new sources automatically.

### `release-preparation-flow.yml` — propagate `failure_reason`

- One-line change to the `update-template` job's `failure_reason` output: now also ORs through `collect-previous-version.outputs.failure_reason` and `collect-default-branch-version.outputs.failure_reason`.
- Effect: when the action fails during release prep, the workflow's user-visible failure reason is the actual cause (`"Failed to read application version via mvn"`, etc.) instead of the generic `"Template update or branch verification failed"` fallback.
- This propagates through to the `upload_results` JSON artifact (`failure_reason` field) — beneficial for matrix-mode aggregation in the platform-lsp orchestrator.
- No infra-error notification routing is wired here by design — release prep is low-volume and doesn't need team-channel triage.

### Documentation

- **`collect-app-version/README.md`** — documented the new input, the three new outputs, and a failure-classification table mapping each failure mode to its `is_infrastructure_error` / `error_category` values.
- **`application-update-flow.md`** — sharpened the outputs table descriptions for `failure_reason` and `error_category`, extended the "Update Application" job description with the new step, added a note in the Version Calculation section.
- **`release-preparation-flow.md`** — added the missing `failure_reason` row to the outputs table (pre-existing doc gap), rewrote the "Version Determination" step description to mention the action and its failure-propagation behavior, added a Related Documentation link to the action README.

## Compatibility

- The two existing callers of `collect-app-version` in `release-preparation-flow.yml` are functionally unchanged — same exit codes, same outputs they consume. The new outputs are now populated on failure (previously empty), benefiting any future consumer that wires them up.
- `application-update.yml`'s notify job already gates the team-channel Slack on `is_infrastructure_error != 'true'` (no change needed in this PR for the routing to take effect).

## Verification

- YAML and bash syntax validated.
- Local stub-`mvn` smoke tests cover four action scenarios (happy / mvn-fail / bad-format / pom-missing) and two bump-step scenarios (happy / `versions:set` fails). All behave as designed.
- Live confirmation pending — next genuine transient `mvn` failure on any `app-*` scheduled run should keep the team channel quiet while the general channel posts a standard infra-error message with the actual cause in `failure_reason`.