### PR TITLE
RANCHER-2961. Post-Merge Flow Robustness - Cleanup Grace + Release Announcement

### DIFF
--- a/.github/docs/post-merge-flow.md
+++ b/.github/docs/post-merge-flow.md
@@ -42,12 +42,13 @@ The workflow validates that the merge was successful and that the PR originated 
 
 ### Variables
 
-| Variable                       | Description                          | Required |
-|--------------------------------|--------------------------------------|----------|
-| `EUREKA_CI_APP_ID`             | GitHub App ID                        | Yes      |
-| `FAR_URL`                      | FOLIO Application Registry URL       | Yes      |
-| `SLACK_NOTIF_CHANNEL`          | Team Slack notification channel      | No       |
-| `GENERAL_SLACK_NOTIF_CHANNEL`  | General Slack notification channel   | No       |
+| Variable                       | Description                                              | Required |
+|--------------------------------|----------------------------------------------------------|----------|
+| `EUREKA_CI_APP_ID`             | GitHub App ID                                            | Yes      |
+| `FAR_URL`                      | FOLIO Application Registry URL                           | Yes      |
+| `SLACK_NOTIF_CHANNEL`          | Team Slack notification channel (per-repo)               | No       |
+| `GENERAL_SLACK_NOTIF_CHANNEL`  | General Slack notification channel (org-level)           | No       |
+| `APP_RELEASE_SLACK_CHANNEL`    | Org-wide channel for release announcements (org-level)   | No       |
 
 ## Workflow Execution Flow
 
@@ -113,11 +114,15 @@ Deletes the merged update branch.
 
 **Steps**:
 1. Generate GitHub App Token
-2. Delete Update Branch via GitHub API
+2. Delete Update Branch via GitHub API. The step first checks whether the ref still exists; a missing ref is treated as a non-failure (already-deleted state).
 
 **Outputs**:
-- `branch_deleted`: `true`, `false`, or `skipped`
-- `failure_reason`: Reason if deletion failed
+- `deleted`: One of:
+  - `true` — branch existed and was deleted
+  - `already_deleted` — branch ref was missing before deletion attempt (non-failure)
+  - `skipped` — no head branch info available
+  - `false` — delete attempt failed (permission/API error)
+- `failure_reason`: Reason if deletion failed (only set when `deleted=false`)
 
 ### 4. Create Release
 **Job**: `release`
@@ -144,7 +149,12 @@ Sends Slack notifications with post-merge results.
 
 **Condition**: Runs if `should_process == 'true'`
 
-**Message Format**:
+**Channels**:
+- `SLACK_NOTIF_CHANNEL` (per-repo) — team summary message
+- `GENERAL_SLACK_NOTIF_CHANNEL` (org-level) — general summary message
+- `APP_RELEASE_SLACK_CHANNEL` (org-level) — release announcement, sent **only when `release_created == 'true'`** (i.e., a new release was actually created — not on `skipped`, `dry_run`, or `false`)
+
+**Summary Message Format** (team and general channels):
 ```
 *app-acquisitions post-merge completed/failed #42*
 
@@ -157,9 +167,16 @@ Release: v2.0.5
 Descriptor URL: <link>
 ```
 
-**Color Coding**:
-- Green: Publish succeeded and branch cleanup succeeded
-- Red: Any operation failed
+The `Branch Cleanup` field renders as `Deleted`, `Previously deleted`, `Skipped`, or `Failed` depending on the `cleanup-branch.deleted` output.
+
+**Release Announcement Format** (`APP_RELEASE_SLACK_CHANNEL` only):
+```
+`app-acquisitions v2.0.5` released https://github.com/folio-org/app-acquisitions/releases/tag/v2.0.5
+```
+
+**Color Coding** (summary messages):
+- Green: Publish succeeded and branch cleanup did not fail (any of `true`, `already_deleted`, `skipped`)
+- Red: Publish failed or branch cleanup returned `false`
 
 ### 6. Workflow Summary
 **Job**: `summarize`
@@ -305,6 +322,6 @@ gh api repos/folio-org/app-acquisitions/contents/application.lock.json \
 
 ---
 
-**Last Updated**: March 2026
-**Workflow Version**: 1.1 (Release notes via compare-state-files)
+**Last Updated**: May 2026
+**Workflow Version**: 1.2 (Graceful already-deleted cleanup; release announcements to `APP_RELEASE_SLACK_CHANNEL`)
 **Compatibility**: GitHub App webhook integration required

--- a/.github/workflows/post-merge-flow.yml
+++ b/.github/workflows/post-merge-flow.yml
@@ -299,6 +299,12 @@ jobs:
             exit 0
           fi
 
+          if ! gh api "repos/$REPO/git/refs/heads/$HEAD_BRANCH" --silent 2>/dev/null; then
+            echo "::notice::Branch '$HEAD_BRANCH' was previously deleted"
+            echo "deleted=already_deleted" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           echo "::notice::Deleting merged update branch: $HEAD_BRANCH"
           if gh api -X DELETE "repos/$REPO/git/refs/heads/$HEAD_BRANCH" 2>/dev/null; then
             echo "::notice::Branch '$HEAD_BRANCH' deleted successfully"
@@ -370,7 +376,7 @@ jobs:
             },
             {
               "title": "Branch Cleanup",
-              "value": "${{ needs.cleanup-branch.outputs.deleted == 'true' && 'Deleted' || (needs.cleanup-branch.outputs.deleted == 'skipped' && 'Skipped' || 'Failed') }}",
+              "value": "${{ needs.cleanup-branch.outputs.deleted == 'true' && 'Deleted' || (needs.cleanup-branch.outputs.deleted == 'already_deleted' && 'Previously deleted' || (needs.cleanup-branch.outputs.deleted == 'skipped' && 'Skipped' || 'Failed')) }}",
               "short": true
             }${{ needs.release.outputs.release_created == 'true' && format(',
             {{
@@ -458,6 +464,20 @@ jobs:
               "attachments": [
                 ${{ env.ATTACHMENT }}
               ]
+            }
+
+      - name: Send Release Announcement
+        if: needs.release.outputs.release_created == 'true' && vars.APP_RELEASE_SLACK_CHANNEL != ''
+        continue-on-error: true
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.EUREKA_CI_SLACK_BOT_TOKEN }}
+          errors: false
+          payload: |
+            {
+              "channel": "${{ vars.APP_RELEASE_SLACK_CHANNEL }}",
+              "text": "`${{ inputs.repo_name }} ${{ needs.release.outputs.tag_name }}` released ${{ needs.release.outputs.release_url }}"
             }
 
   summarize:


### PR DESCRIPTION
## Summary

- Adds an org-wide release announcement to a dedicated Slack channel (`vars.APP_RELEASE_SLACK_CHANNEL`) whenever the post-merge flow successfully creates a new GitHub Release for an `app-*` repository — implements [RANCHER-2961](https://folio-org.atlassian.net/browse/RANCHER-2961).
- Makes the **Cleanup Update Branch** job tolerate an already-deleted update branch instead of reporting a misleading failure in Slack.
- Updates `post-merge-flow.md` to reflect the new variable, the new cleanup state, and the new announcement format.

## Why

- **Release announcement (RANCHER-2961):** these posts are currently sent by hand each time an `app-*` release is cut — this PR replaces that manual activity with automation. Implementing it inside `post-merge-flow.yml`'s existing `notify` job (instead of adding a `create`-event workflow to every `app-*` repo) keeps the trigger logic centralized and ensures we only post once a release is actually produced.
- **Cleanup grace:** a previously-deleted update branch (manual cleanup, retried run, etc.) caused the cleanup step to set `deleted=false` with `failure_reason="Failed to delete update branch: …"`, flipping the whole post-merge Slack title to "failed" and surfacing a fake Failure Reason field. The desired end state was already in place — this should not be reported as a failure.

## Changes

`.github/workflows/post-merge-flow.yml`
- **`Delete Update Branch`** (cleanup-branch job): GET the ref before DELETE. Missing ref → `deleted=already_deleted`, no `failure_reason`, exit 0.
- **Slack "Branch Cleanup" field**: ternary extended to render `already_deleted` as **"Previously deleted"** (with `Deleted` / `Skipped` / `Failed` paths preserved).
- **New step `Send Release Announcement`** in the `notify` job:
  - Conditions: `needs.release.outputs.release_created == 'true' && vars.APP_RELEASE_SLACK_CHANNEL != ''`
  - Uses the existing `slackapi/slack-github-action@v2.1.1` and `EUREKA_CI_SLACK_BOT_TOKEN`
  - `continue-on-error: true` (Slack outage never breaks the workflow)
  - Payload:
    ```
    `<repo_name> <tag_name>` released <release_url>
    ```
    Backticks render as inline code, URL auto-linkifies — matches the existing `Jack Golding` post format.

`.github/docs/post-merge-flow.md`
- **Variables** table: added `APP_RELEASE_SLACK_CHANNEL`, clarified per-repo vs. org scope on the existing channel vars.
- **Cleanup Update Branch**: corrected output name (`branch_deleted` → `deleted`), enumerated all four states including `already_deleted`, and noted `failure_reason` is set only on hard failure.
- **Send Notifications**: added a Channels list, a separate Release Announcement format example, and updated the color-coding to reflect `already_deleted` being treated as success.
- Footer bumped: `Last Updated: May 2026`, `Workflow Version: 1.2`.

## Configuration

Set the org-level variable to enable the announcement:

```
APP_RELEASE_SLACK_CHANNEL = #folio-applications-releases
```

If unset/empty, the new step is skipped via the `if` guard — no errors, no warnings.
