### PR TITLE
RANCHER-2977. Replace mvn version read in collect-app-version action with awk-based parser

### DIFF
--- a/.github/actions/collect-app-version/README.md
+++ b/.github/actions/collect-app-version/README.md
@@ -1,12 +1,13 @@
 # Collect Application Version
 
-A GitHub Action for collecting and parsing Maven application versions from FOLIO repositories. This action extracts version information from `pom.xml` files and breaks it down into semantic version components, with special handling for SNAPSHOT versions.
+A GitHub Action for collecting and parsing Maven application versions from FOLIO repositories. This action extracts the project version directly from `pom.xml` and breaks it down into semantic version components, with special handling for SNAPSHOT versions.
 
 ## Features
 
-- **Maven version extraction**: Reads version from `pom.xml` using Maven
+- **Direct pom.xml parsing**: Reads the project `<version>` element via `awk` — no Maven invocation, no Maven Central dependency
 - **Semantic version parsing**: Breaks down versions into major, minor, patch components
 - **SNAPSHOT support**: Properly handles SNAPSHOT versions with build numbers
+- **Parent-aware**: Skips any `<version>` nested in a `<parent>` block so the project version is selected, not the parent's
 - **Cross-repository support**: Can collect versions from any FOLIO application repository
 - **Validation**: Ensures version follows expected semantic versioning patterns
 
@@ -90,9 +91,8 @@ jobs:
 | Input           | Description                                                                              | Required | Default                          |
 |-----------------|------------------------------------------------------------------------------------------|----------|----------------------------------|
 | `app_name`      | Full repository path (e.g., `folio-org/app-platform`)                                    | ✅       | \-                               |
-| `branch`        | Branch name to collect version from                                                      | ✅       | \-                               |
-| `token`         | GitHub token with repository read permissions                                            | ❌       | `${{ github.token }}` if not set |
-| `skip_checkout` | Skip the internal `actions/checkout` when the caller already has the repo in workspace   | ❌       | `'false'`                        |
+| `branch`        | Branch (or any git ref) to read `pom.xml` from                                           | ✅       | \-                               |
+| `token`         | GitHub token with read access to the target repository                                   | ❌       | `${{ github.token }}` if not set |
 
 ## Outputs
 
@@ -104,19 +104,18 @@ jobs:
 | `patch`                   | Patch version number                                                                   | `3`                 |
 | `is_snapshot`             | Whether this is a SNAPSHOT version                                                     | `true` or `false`   |
 | `build_number`            | Build number (for SNAPSHOT versions)                                                   | `45`                |
-| `is_infrastructure_error` | `true` only when `mvn` itself failed (treat as transient); `false` on success or app-level failures | `true` or `false`   |
-| `error_category`          | `NONE` \| `INFRASTRUCTURE` \| `POM_NOT_FOUND` \| `INVALID_VERSION_FORMAT`              | `NONE`              |
-| `failure_reason`          | Standard failure message when the read failed (empty on success)                       | `Failed to read application version via mvn` |
+| `is_infrastructure_error` | Reserved for backwards compatibility; always emits `false` after [RANCHER-2977](https://folio-org.atlassian.net/browse/RANCHER-2977) (no `mvn` invocation remains) | `false`             |
+| `error_category`          | `NONE` \| `POM_NOT_FOUND` \| `INVALID_VERSION_FORMAT`                                  | `NONE`              |
+| `failure_reason`          | Standard failure message when the read failed (empty on success)                       | `Could not extract project <version> from pom.xml` |
 
-The action always exits 1 on any failure, but classifies the cause so callers can route notifications differently:
+The action always exits 1 on any failure, classifying the cause:
 
 | Failure                                     | Exit | `is_infrastructure_error` | `error_category`         |
 |---------------------------------------------|------|---------------------------|--------------------------|
-| `pom.xml` not found in workspace            | 1    | `false`                   | `POM_NOT_FOUND`          |
-| `mvn` exit non-zero (likely transient)      | 1    | `true`                    | `INFRASTRUCTURE`         |
-| Version doesn't match `X.Y.Z[-SNAPSHOT[.N]]`| 1    | `false`                   | `INVALID_VERSION_FORMAT` |
+| `pom.xml` not found on `<branch>` (or `gh api` request failed) | 1 | `false` | `POM_NOT_FOUND`          |
+| Version doesn't match `X.Y.Z[-SNAPSHOT[.N]]`                   | 1 | `false` | `INVALID_VERSION_FORMAT` |
 
-Callers that suppress noisy team-channel notifications on transient failures (see `application-update-flow.yml`) should gate on `is_infrastructure_error == 'true'` only — the two app-level categories should still surface to the team because they indicate real configuration/setup bugs.
+`is_infrastructure_error` and the `INFRASTRUCTURE` category remain in the output schema for backwards compatibility with callers wired to suppress team-channel notifications on transient mvn flakes (see [RANCHER-2962](https://folio-org.atlassian.net/browse/RANCHER-2962)). Since the implementation no longer invokes `mvn`, that failure class is structurally absent and the flag is always `false`.
 
 ## Version Format Support
 
@@ -132,8 +131,8 @@ This action supports Maven versions following these patterns:
 
 ## How It Works
 
-1. **Repository Checkout**: Checks out the specified application repository and branch
-2. **Maven Version Extraction**: Uses Maven to extract the version from `pom.xml`
+1. **POM Fetch**: Reads `pom.xml` from `repos/<app_name>/contents/pom.xml?ref=<branch>` via the GitHub Contents API (`gh api`) — no repository checkout, no Maven invocation
+2. **POM Parse**: `awk` finds the first `<version>` element outside any `<parent>` block (the project's own version)
 3. **Version Validation**: Validates the version follows semantic versioning patterns
 4. **Component Parsing**: Breaks down the version into individual components
 5. **Output Generation**: Provides all components as action outputs
@@ -142,19 +141,16 @@ This action supports Maven versions following these patterns:
 
 ### Repository Structure
 The target repository must:
-- Be a Maven project with a `pom.xml` file in the root
-- Have the version defined in the `<version>` element
+- Have a `pom.xml` file in the root
+- Have the project version defined in the top-level `<version>` element (not inside a `<parent>` block)
 - Follow semantic versioning conventions
-
-### Maven
-This action uses Maven (`mvn`) which is pre-installed on GitHub runners.
 
 ### Permissions
 The calling workflow needs appropriate permissions:
 
 ```yaml
 permissions:
-  contents: read     # To checkout repositories
+  contents: read     # To read pom.xml via the GitHub Contents API
 ```
 
 ## Error Handling
@@ -163,7 +159,7 @@ The action provides clear error messages for common issues:
 
 - **Missing pom.xml**: If the repository doesn't contain a `pom.xml` file
 - **Invalid version format**: If the version doesn't follow semantic versioning
-- **Maven execution failure**: If Maven cannot extract the version
+- **Could not extract project `<version>`**: If `pom.xml` exists but no top-level `<version>` element is found outside `<parent>` (rare; usually means a malformed pom)
 
 ## Use Cases
 
@@ -311,10 +307,9 @@ Implement proper error handling for version collection failures:
 - For private repositories, ensure the token has appropriate permissions
 - Check repository visibility and access settings
 
-**Maven execution failure**
-- The repository may not be a valid Maven project
-- Dependencies might be missing or misconfigured
-- Check the Maven project structure and configuration
+**Could not extract project `<version>`**
+- The first `<version>` element outside any `<parent>` block is treated as the project version. If your pom has neither, the action fails with `INVALID_VERSION_FORMAT`.
+- Inspect the pom: there must be a top-level `<version>X.Y.Z[-SNAPSHOT[.N]]</version>` element.
 
 ## Integration with FOLIO Workflows
 

--- a/.github/actions/collect-app-version/action.yml
+++ b/.github/actions/collect-app-version/action.yml
@@ -10,10 +10,6 @@ inputs:
   token:
     description: 'GitHub token with organization read permissions'
     required: false
-  skip_checkout:
-    description: 'Skip checkout when caller already has the repo in the workspace'
-    required: false
-    default: 'false'
 
 outputs:
   version:
@@ -35,10 +31,10 @@ outputs:
     description: 'Build number'
     value: ${{ steps.collect-version.outputs.build_number }}
   is_infrastructure_error:
-    description: 'true only when mvn itself failed (treat as transient)'
+    description: 'Reserved for backwards compatibility; always emits `false` (no mvn invocation after RANCHER-2977)'
     value: ${{ steps.collect-version.outputs.is_infrastructure_error }}
   error_category:
-    description: 'NONE | INFRASTRUCTURE (mvn failure) | POM_NOT_FOUND | INVALID_VERSION_FORMAT'
+    description: 'NONE | POM_NOT_FOUND | INVALID_VERSION_FORMAT'
     value: ${{ steps.collect-version.outputs.error_category }}
   failure_reason:
     description: 'Standard failure message if the read failed'
@@ -47,31 +43,15 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - name: Checkout branch
-      if: inputs.skip_checkout != 'true'
-      uses: actions/checkout@v4
-      with:
-        token: ${{ inputs.token || github.token }}
-        repository: ${{ inputs.app_name }}
-        ref: ${{ inputs.branch }}
-        fetch-depth: 0
-
     - name: Collect Application Version
       id: collect-version
       shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token || github.token }}
+        APP_NAME: ${{ inputs.app_name }}
+        BRANCH: ${{ inputs.branch }}
       run: |
         set -eo pipefail
-
-        fail_infra() {
-          local msg="$1"
-          echo "::error::$msg (classified as INFRASTRUCTURE)"
-          {
-            echo "is_infrastructure_error=true"
-            echo "error_category=INFRASTRUCTURE"
-            echo "failure_reason=$msg"
-          } >> "$GITHUB_OUTPUT"
-          exit 1
-        }
 
         fail_app() {
           local category="$1"
@@ -85,14 +65,24 @@ runs:
           exit 1
         }
 
-        test -f pom.xml || fail_app "POM_NOT_FOUND" "pom.xml not found in repository"
+        if ! pom_b64=$(gh api "repos/${APP_NAME}/contents/pom.xml?ref=${BRANCH}" --jq '.content' 2>/dev/null); then
+          fail_app "POM_NOT_FOUND" "Failed to fetch pom.xml from ${APP_NAME}@${BRANCH}"
+        fi
 
-        if ! current_version=$(mvn -B -ntp -q \
-                    -Dexec.executable=echo \
-                    -Dexec.args='${project.version}' \
-                    --non-recursive exec:exec \
-                    -f pom.xml); then
-          fail_infra "Failed to read application version via mvn"
+        current_version=$(printf '%s' "$pom_b64" | base64 -d | awk '
+          /<parent>/    { in_parent=1 }
+          /<\/parent>/  { in_parent=0; next }
+          in_parent     { next }
+          /<version>/ {
+            if (match($0, /<version>[^<]+<\/version>/)) {
+              print substr($0, RSTART+9, RLENGTH-19)
+              exit
+            }
+          }
+        ')
+
+        if [ -z "$current_version" ]; then
+          fail_app "INVALID_VERSION_FORMAT" "Could not extract project <version> from pom.xml"
         fi
 
         echo "::notice::Current version from pom.xml: $current_version"

--- a/.github/docs/application-update-flow.md
+++ b/.github/docs/application-update-flow.md
@@ -80,7 +80,7 @@ Determines the source branch and checks for existing PRs:
 Uses the `generate-application-descriptor` action with `generation_mode: update`:
 
 **Process**:
-- Reads current pom version via the `collect-app-version` action (`skip_checkout: true`); failures are classified as `INFRASTRUCTURE` (transient mvn) or `INVALID_VERSION_FORMAT` / `POM_NOT_FOUND` (application-level)
+- Reads current pom version via the `collect-app-version` action (reads `pom.xml` directly via the GitHub Contents API; no `mvn` invocation); failures are classified as `INVALID_VERSION_FORMAT` or `POM_NOT_FOUND`
 - Increments patch version and runs `mvn versions:set` (PR-mode runs only); `mvn` failures here are classified as `INFRASTRUCTURE`
 - Resolves version constraints from `application.template.json` (^2.0.0 → 2.3.1)
 - Full module synchronization (add/remove/upgrade/downgrade)

--- a/.github/docs/release-preparation-flow.md
+++ b/.github/docs/release-preparation-flow.md
@@ -75,7 +75,7 @@ All commits use the reusable **`commit-and-push-changes.yml`** workflow for cons
    - Reads current version from source branch via the [`collect-app-version`](../actions/collect-app-version/README.md) action
    - Optionally reads default-branch version (snapshot fallback case) via the same action
    - Calculates new release version (typically major version increment, or minor bump for snapshot fallback)
-   - If the action fails (mvn error, missing pom, unparseable version), the actual `failure_reason` from the action propagates through the job's `failure_reason` output instead of the generic `"Template update or branch verification failed"` fallback
+   - If the action fails (missing pom, unparseable version), the actual `failure_reason` from the action propagates through the job's `failure_reason` output instead of the generic `"Template update or branch verification failed"` fallback
 
 3. **Template Update**
    - Updates `application.template.json`:
@@ -548,7 +548,7 @@ new_patch=0
 - **[Release Preparation (Public Wrapper)](release-preparation.md)**: Public wrapper with notifications
 - **[Distributed Orchestration](distributed-orchestration.md)**: Cross-repository coordination
 - **[Commit and Push Changes](commit-and-push-changes.md)**: Reusable commit workflow
-- **[Collect Application Version Action](../actions/collect-app-version/README.md)**: Reads version from pom.xml; classifies failures as `INFRASTRUCTURE` / `POM_NOT_FOUND` / `INVALID_VERSION_FORMAT`
+- **[Collect Application Version Action](../actions/collect-app-version/README.md)**: Reads version from pom.xml via the GitHub Contents API; classifies failures as `POM_NOT_FOUND` / `INVALID_VERSION_FORMAT`
 - **[Security Implementation](security-implementation.md)**: Authorization patterns
 - **[FOLIO Release Process](https://folio-org.atlassian.net/wiki/spaces/FOLIJET/pages/886178625/Release+preparation)**: Official documentation
 

--- a/.github/workflows/application-update-flow.yml
+++ b/.github/workflows/application-update-flow.yml
@@ -338,7 +338,6 @@ jobs:
           needs.prepare-context.outputs.update_branch_exists != 'true'
         uses: folio-org/kitfox-github/.github/actions/collect-app-version@master
         with:
-          skip_checkout: 'true'
           app_name: ${{ inputs.repo }}
           branch: ${{ needs.prepare-context.outputs.target_branch }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-preparation-flow.yml
+++ b/.github/workflows/release-preparation-flow.yml
@@ -98,13 +98,6 @@ jobs:
       NEW_BRANCH: ${{ inputs.new_release_branch }}
 
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          repository: ${{ inputs.repo }}
-          fetch-depth: 0
-
       - name: Verify Branches
         id: verify-branches
         env:
@@ -112,19 +105,19 @@ jobs:
         run: |
           set -eo pipefail
 
-          if git ls-remote --exit-code --heads origin "$NEW_BRANCH" >/dev/null 2>&1; then
+          if gh api "repos/${{ inputs.repo }}/branches/$NEW_BRANCH" --silent 2>/dev/null; then
             echo "error=New release branch '$NEW_BRANCH' already exists" >> "$GITHUB_OUTPUT"
             echo "::error::New release branch '$NEW_BRANCH' already exists"
             exit 1
           fi
 
-          if git ls-remote --exit-code --heads origin "$PREV_BRANCH" >/dev/null 2>&1; then
+          if gh api "repos/${{ inputs.repo }}/branches/$PREV_BRANCH" --silent 2>/dev/null; then
             echo "::notice::Using previous release branch: $PREV_BRANCH"
             echo "source_branch=$PREV_BRANCH" >> "$GITHUB_OUTPUT"
             echo "has_previous_branch=true" >> "$GITHUB_OUTPUT"
 
           elif [[ "${{ inputs.use_snapshot_fallback }}" == "true" ]] \
-              && git ls-remote --exit-code --heads origin "snapshot" >/dev/null 2>&1; then
+              && gh api "repos/${{ inputs.repo }}/branches/snapshot" --silent 2>/dev/null; then
 
             echo "::warning::Previous release branch not found, using snapshot branch as fallback"
             echo "source_branch=snapshot" >> "$GITHUB_OUTPUT"
@@ -145,11 +138,19 @@ jobs:
           echo "::notice::Default branch is: $default_branch"
           echo "default_branch=$default_branch" >> "$GITHUB_OUTPUT"
 
-          if ! git ls-remote --exit-code --heads origin "snapshot" >/dev/null 2>&1; then
+          if ! gh api "repos/${{ inputs.repo }}/branches/snapshot" --silent 2>/dev/null; then
             echo "error=Missing branch. The snapshot branch does not exist" >> "$GITHUB_OUTPUT"
             echo "::error::Missing branch. The snapshot branch does not exist"
             exit 1
           fi
+
+      - name: Checkout Source Branch
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ inputs.repo }}
+          ref: ${{ steps.verify-branches.outputs.source_branch }}
+          fetch-depth: 0
 
       - name: Collect Previous Version
         id: collect-previous-version


### PR DESCRIPTION
## Summary

- **Action `collect-app-version`**: now reads `pom.xml` via `gh api repos/<repo>/contents/pom.xml?ref=<branch>` and parses with `awk` — no more `mvn` invocation, no in-action checkout. The awk parser skips any `<parent>` block so the project's own `<version>` is selected, not the parent's.
- **Action contract**: removed the `skip_checkout` input and the internal `actions/checkout@v4` step. Input/output schema otherwise unchanged. `is_infrastructure_error` retained in the output schema for backwards compatibility but always emits `false`; `error_category` enum reduced to `NONE | POM_NOT_FOUND | INVALID_VERSION_FORMAT`.
- **Caller `application-update-flow.yml`**: removed the obsolete `skip_checkout: 'true'` argument from the `collect-app-version` call. The job's own prior checkout is untouched (still needed for the downstream `bump-version` step's `mvn versions:set`, which is unchanged).
- **Caller `release-preparation-flow.yml` (`update-template` job)**:
  - Replaced four `git ls-remote --exit-code --heads origin "$BRANCH"` calls in `Verify Branches` with `gh api repos/.../branches/<name> --silent` (consistent with the existing `gh api` call already in the step).
  - Removed the initial `Checkout Repository` step (no longer needed once `Verify Branches` uses `gh api` and `source_branch` is checked out explicitly).
  - Added an explicit `Checkout Source Branch` step after `Verify Branches` to provide the workspace state the downstream `Update Application Template` and `Update POM Version` steps need (previously provided implicitly by the action's internal checkout).
- **Docs**: action README updated for the new contract; `application-update-flow.md` and `release-preparation-flow.md` updated to drop stale `skip_checkout` / `INFRASTRUCTURE`-from-this-action references. Other `INFRASTRUCTURE` references left intact — they describe the untouched `mvn versions:set` in `bump-version`, which still legitimately emits that category per RANCHER-2962.

## Motivation

`collect-app-version` was running `mvn -B -ntp -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec -f pom.xml` purely to read the project version. That invocation downloads `exec-maven-plugin` from Maven Central — the transient-failure surface documented in RANCHER-2962. The `is_infrastructure_error` classification added post-2962 helps triage those failures but doesn't prevent them; the action is called ~every 20 min × 40 apps in `application-update-flow.yml`, so flake exposure was non-trivial.

A pre-merge scan of all 41 FOLIO app `pom.xml` files (40 in `platform-descriptor.json` plus `app-rtac-cache` and `app-z3950`) confirmed every project `<version>` is a literal SemVer string — Maven property substitution is not used in practice. The mvn invocation could be replaced with a direct Contents-API read, eliminating the Maven Central dependency entirely.

## Unblocks

The RANCHER-2951 per-app worker (`post-release-bump-flow.yml`, in a separate PR yet to be opened) will call the refactored action instead of hand-rolling `gh api` + `awk` itself.

Refs: RANCHER-2977