### PR TITLE
RANCHER-2978. Make post-Merge release notes robust

### DIFF
--- a/.github/actions/compare-state-files/README.md
+++ b/.github/actions/compare-state-files/README.md
@@ -14,15 +14,15 @@ The action identifies added, removed, and updated modules between the two states
 
 ## Inputs
 
-| Name                | Description                                           | Required | Default                          |
-|---------------------|-------------------------------------------------------|----------|----------------------------------|
-| `repo`              | Repository name in org/repo format                    | **Yes**  | -                                |
-| `base-source-type`  | Type of base source: "artifact" or "branch"           | **Yes**  | -                                |
-| `base-source`       | Base source: artifact name or branch name             | **Yes**  | -                                |
-| `head-source-type`  | Type of head source: "artifact" or "branch"           | **Yes**  | -                                |
-| `head-source`       | Head source: artifact name or branch name             | **Yes**  | -                                |
-| `state-file`        | Name of the state file (application descriptor)       | No       | `application-descriptor.json`    |
-| `github-token`      | GitHub token for API access                           | **Yes**  | -                                |
+| Name                | Description                                                         | Required | Default                |
+|---------------------|---------------------------------------------------------------------|----------|------------------------|
+| `repo`              | Repository name in org/repo format                                  | **Yes**  | -                      |
+| `base-source-type`  | Type of base source: `artifact` or `branch`                         | **Yes**  | -                      |
+| `base-source`       | Base source: artifact name (for `artifact`), or any git ref — branch, tag, or commit SHA — passed to the Contents API as `ref=…` (for `branch`) | **Yes**  | -                      |
+| `head-source-type`  | Type of head source: `artifact` or `branch`                         | **Yes**  | -                      |
+| `head-source`       | Head source: artifact name, or any git ref (branch/tag/SHA) — see `base-source`                                                                | **Yes**  | -                      |
+| `state-file`        | Name of the state file                                              | No       | `application.lock.json`|
+| `github-token`      | GitHub token for API access                                         | **Yes**  | -                      |
 
 ## Outputs
 
@@ -173,13 +173,12 @@ The action expects JSON files with the following structure:
 
 ## Error Handling
 
-The action will fail if:
-- State file is not found in the specified branch
-- State file is not found in the specified artifact
-- JSON parsing fails for state files
-- Git operations fail (for branch comparisons)
+The action fails loudly (non-zero exit + `::error::` annotation) if:
+- The Contents API returns any HTTP 4xx/5xx for the state file (e.g. the ref does not exist, the state file does not exist at that ref, or the token lacks permission). The action uses `curl -fsS` so HTTP errors propagate immediately — the JSON error body is never written to disk and never silently parsed as an "empty state".
+- The state file is not found in the specified artifact.
+- JSON parsing fails for either state file.
 
-All errors are reported using GitHub Actions error annotations.
+All errors are reported using GitHub Actions error annotations and stop the workflow at the step boundary.
 
 ## Example Workflow
 

--- a/.github/actions/compare-state-files/action.yml
+++ b/.github/actions/compare-state-files/action.yml
@@ -62,12 +62,15 @@ runs:
         WORK_DIR: ${{ steps.gen-dir.outputs.work_dir }}
       run: |
         api_url="https://api.github.com/repos/$REPO/contents/$STATE_FILE?ref=$BRANCH"
-        curl -sS -H "Authorization: token $GITHUB_TOKEN" \
-          -H "Accept: application/vnd.github.v3.raw" \
-          "$api_url" -o "$WORK_DIR/base_state.json"
+        if ! curl -fsS -H "Authorization: token $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github.v3.raw" \
+              "$api_url" -o "$WORK_DIR/base_state.json"; then
+          echo "::error::Failed to download $STATE_FILE from $REPO@$BRANCH (HTTP error)"
+          exit 1
+        fi
 
-        if [ $? -ne 0 ] || [ ! -s "$WORK_DIR/base_state.json" ]; then
-          echo "::error::Failed to download $STATE_FILE from branch $BRANCH"
+        if [ ! -s "$WORK_DIR/base_state.json" ]; then
+          echo "::error::Downloaded $STATE_FILE from $REPO@$BRANCH is empty"
           exit 1
         fi
 
@@ -103,12 +106,15 @@ runs:
         WORK_DIR: ${{ steps.gen-dir.outputs.work_dir }}
       run: |
         api_url="https://api.github.com/repos/$REPO/contents/$STATE_FILE?ref=$BRANCH"
-        curl -sS -H "Authorization: token $GITHUB_TOKEN" \
-          -H "Accept: application/vnd.github.v3.raw" \
-          "$api_url" -o "$WORK_DIR/head_state.json"
+        if ! curl -fsS -H "Authorization: token $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github.v3.raw" \
+              "$api_url" -o "$WORK_DIR/head_state.json"; then
+          echo "::error::Failed to download $STATE_FILE from $REPO@$BRANCH (HTTP error)"
+          exit 1
+        fi
 
-        if [ $? -ne 0 ] || [ ! -s "$WORK_DIR/head_state.json" ]; then
-          echo "::error::Failed to download $STATE_FILE from branch $BRANCH"
+        if [ ! -s "$WORK_DIR/head_state.json" ]; then
+          echo "::error::Downloaded $STATE_FILE from $REPO@$BRANCH is empty"
           exit 1
         fi
 

--- a/.github/actions/get-pr-info/README.md
+++ b/.github/actions/get-pr-info/README.md
@@ -16,16 +16,17 @@ This action retrieves comprehensive information about a GitHub pull request usin
 
 ## Outputs
 
-| Output             | Description                                          |
-|--------------------|------------------------------------------------------|
-| `pr_exists`        | Whether the PR exists and is accessible (true/false) |
-| `current_head_sha` | Current HEAD SHA of the pull request                 |
-| `head_ref`         | Head branch reference of the pull request            |
-| `base_ref`         | Base branch reference of the pull request            |
-| `labels`           | JSON array of label names                            |
-| `state`            | State of the pull request (open, closed)             |
-| `skip_reason`      | Reason for skipping if PR does not exist             |
-| `body`             | Body/description of the pull request                 |
+| Output             | Description                                                          |
+|--------------------|----------------------------------------------------------------------|
+| `pr_exists`        | Whether the PR exists and is accessible (true/false)                 |
+| `current_head_sha` | Current HEAD SHA of the pull request (`pr.head.sha`)                 |
+| `base_sha`         | Base branch SHA the pull request diverged from (`pr.base.sha`)       |
+| `head_ref`         | Head branch reference of the pull request                            |
+| `base_ref`         | Base branch reference of the pull request                            |
+| `labels`           | JSON array of label names                                            |
+| `state`            | State of the pull request (open, closed)                             |
+| `skip_reason`      | Reason for skipping if PR does not exist                             |
+| `body`             | Body/description of the pull request                                 |
 
 ## Usage
 
@@ -87,6 +88,7 @@ This action retrieves comprehensive information about a GitHub pull request usin
     echo "Head Branch: ${{ steps.pr-info.outputs.head_ref }}"
     echo "Base Branch: ${{ steps.pr-info.outputs.base_ref }}"
     echo "Current SHA: ${{ steps.pr-info.outputs.current_head_sha }}"
+    echo "Base SHA:    ${{ steps.pr-info.outputs.base_sha }}"
     echo "State: ${{ steps.pr-info.outputs.state }}"
     echo "Labels: ${{ steps.pr-info.outputs.labels }}"
 ```
@@ -133,6 +135,7 @@ When the action succeeds, the outputs will look like:
 ```yaml
 pr_exists: 'true'
 current_head_sha: 'abc123def456...'
+base_sha: '0fedcba987654...'
 head_ref: 'feature/new-feature'
 base_ref: 'main'
 labels: '["bug", "priority-high", "release"]'
@@ -146,6 +149,7 @@ When the action fails:
 ```yaml
 pr_exists: 'false'
 current_head_sha: ''
+base_sha: ''
 head_ref: ''
 base_ref: ''
 labels: ''

--- a/.github/actions/get-pr-info/action.yml
+++ b/.github/actions/get-pr-info/action.yml
@@ -19,8 +19,11 @@ outputs:
     description: 'Whether the PR exists and is accessible'
     value: ${{ steps.pr-info.outputs.pr_exists }}
   current_head_sha:
-    description: 'Current HEAD SHA of the pull request'
+    description: 'Current HEAD SHA of the pull request (pr.head.sha)'
     value: ${{ steps.pr-info.outputs.current_head_sha }}
+  base_sha:
+    description: 'Base branch SHA the pull request diverged from (pr.base.sha)'
+    value: ${{ steps.pr-info.outputs.base_sha }}
   head_ref:
     description: 'Head branch reference of the pull request'
     value: ${{ steps.pr-info.outputs.head_ref }}
@@ -77,10 +80,12 @@ runs:
             console.log(`  Base: ${pr.base.ref}`);
             console.log(`  Head: ${pr.head.ref}`);
             console.log(`  Current SHA: ${pr.head.sha}`);
+            console.log(`  Base SHA: ${pr.base.sha}`);
             console.log(`  Labels: ${labels.join(', ') || 'none'}`);
 
             core.setOutput('pr_exists', 'true');
             core.setOutput('current_head_sha', pr.head.sha);
+            core.setOutput('base_sha', pr.base.sha);
             core.setOutput('head_ref', pr.head.ref);
             core.setOutput('base_ref', pr.base.ref);
             core.setOutput('labels', JSON.stringify(labels));

--- a/.github/docs/post-merge-flow.md
+++ b/.github/docs/post-merge-flow.md
@@ -60,12 +60,11 @@ Validates merge status and configuration before proceeding.
 **Steps**:
 1. Check Merge Status - verify PR was actually merged
 2. Generate GitHub App Token
-3. Get Pull Request Information
+3. Get Pull Request Information - returns `pr.base.sha` and `pr.head.sha` via `get-pr-info` action
 4. Get Update Configuration
 5. Validate Configuration
-6. Find Previous Release Tag - looks up latest release via `gh release list`
-7. Compare with Previous Release - uses `compare-state-files` action to compute module diff between previous tag and current branch
-8. Build Release Notes - formats module diff as "Updated Modules:" list; falls back to listing all modules for first releases
+6. Compare PR State - uses `compare-state-files` action to compute the module diff between `pr.base.sha` (state before the PR) and `pr.head.sha` (state after the PR). Independent of merge strategy; on HTTP error against either SHA the step fails loud
+7. Build Release Notes - formats the module diff as an "Updated Modules:" list; empty when the PR introduces no module changes
 
 **Validation Logic** (steps 1-5):
 - Skip if PR was closed without merging (`merged != 'true'`)
@@ -323,5 +322,5 @@ gh api repos/folio-org/app-acquisitions/contents/application.lock.json \
 ---
 
 **Last Updated**: May 2026
-**Workflow Version**: 1.2 (Graceful already-deleted cleanup; release announcements to `APP_RELEASE_SLACK_CHANNEL`)
+**Workflow Version**: 1.3 (PR-SHA-driven module diff; strict HTTP in `compare-state-files`)
 **Compatibility**: GitHub App webhook integration required

--- a/.github/workflows/post-merge-flow.yml
+++ b/.github/workflows/post-merge-flow.yml
@@ -149,56 +149,28 @@ jobs:
           echo "should_process=true" >> "$GITHUB_OUTPUT"
           echo "::notice::Configuration validation successful for branch $TARGET_BRANCH (update_branch: $UPDATE_BRANCH, publish: $PUBLISH, release: $RELEASE)"
 
-      - name: Find Previous Release Tag
-        id: prev-release
-        if: steps.validate-config.outputs.should_process == 'true'
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          REPO: ${{ inputs.repo_owner }}/${{ inputs.repo_name }}
-        run: |
-          PREV_TAG=$(gh release list --repo "$REPO" --limit 1 --exclude-pre-releases --json tagName --jq '.[0].tagName // empty' 2>/dev/null)
-          if [[ -n "$PREV_TAG" ]]; then
-            echo "::notice::Previous release tag: $PREV_TAG"
-            echo "tag=$PREV_TAG" >> "$GITHUB_OUTPUT"
-            echo "found=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::notice::No previous release found"
-            echo "found=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Compare with Previous Release
         id: compare
-        if: steps.prev-release.outputs.found == 'true'
+        if: steps.validate-config.outputs.should_process == 'true'
         uses: folio-org/kitfox-github/.github/actions/compare-state-files@master
         with:
           repo: ${{ inputs.repo_owner }}/${{ inputs.repo_name }}
           base-source-type: branch
-          base-source: ${{ steps.prev-release.outputs.tag }}
+          base-source: ${{ steps.pr-info.outputs.base_sha }}
           head-source-type: branch
-          head-source: ${{ steps.pr-info.outputs.base_ref || inputs.base_branch }}
+          head-source: ${{ steps.pr-info.outputs.current_head_sha }}
           github-token: ${{ steps.app-token.outputs.token }}
 
       - name: Build Release Notes
         id: build-notes
         if: steps.validate-config.outputs.should_process == 'true'
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          REPO: ${{ inputs.repo_owner }}/${{ inputs.repo_name }}
-          BRANCH: ${{ steps.pr-info.outputs.base_ref || inputs.base_branch }}
-          PREV_FOUND: ${{ steps.prev-release.outputs.found }}
           UPDATED_MODULES: ${{ steps.compare.outputs.updated-modules }}
         run: |
-          if [[ "$PREV_FOUND" == "true" && -n "$UPDATED_MODULES" ]]; then
+          if [[ -n "$UPDATED_MODULES" ]]; then
             NOTES="Updated Modules:"$'\n'"$UPDATED_MODULES"
           else
-            MODULES=$(gh api "repos/$REPO/contents/application.lock.json?ref=$BRANCH" \
-              -H "Accept: application/vnd.github.v3.raw" 2>/dev/null | \
-              jq -r '(.modules[]?, .uiModules[]?) | "\(.name): \(.version)"' 2>/dev/null || echo "")
-            if [[ -n "$MODULES" ]]; then
-              NOTES="Modules:"$'\n'"$MODULES"
-            else
-              NOTES=""
-            fi
+            NOTES=""
           fi
 
           echo "notes<<EOF" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Fixes [RANCHER-2978](https://folio-org.atlassian.net/browse/RANCHER-2978). Post-merge release notes for `app-*` releases now reflect what the merged PR actually changed instead of a misleading "everything is new" list, and `compare-state-files` no longer swallows HTTP errors silently.

## Why

Run [25679593124](https://github.com/folio-org/kitfox-github/actions/runs/25679593124/job/75387227230) created v2.1.2 of `app-platform-minimal` with release notes listing all 21 modules as `(new)` — the actual PR introduced one change (`mod-scheduler 4.0.0 → 4.0.1`). Two cascading bugs in the pre-check job:

1. **`Find Previous Release Tag`** ran `gh release list --limit 1` and got the most recently *published* tag across all release branches. For v2.1.2 on `R1-2026` that was `v2.0.52` — a Sunflower backport on `v2.0.52_branch` published two days before v2.1.2 — instead of `v2.1.1`. The lookup had no awareness of which release line the run belonged to.
2. **`compare-state-files`** used bare `curl -sS` (no `-f`). On HTTP 404 the call exited 0 and wrote the JSON error body to the state file. The existing `[ ! -s file ]` check passed (the file was non-empty), `jq -r '.modules[]?'` silently returned nothing for the missing `.modules`, and every head module ended up labelled `(new)`. The bad base from #1 happened to be a tag that predated `application.lock.json`, so the 404 path got exercised — but the action would have produced the same silently-wrong output for any HTTP error.

## Approach

Drop the tag-lookup entirely and drive the diff straight off the PR object that triggered the post-merge run. `pr.base.sha → pr.head.sha` is the canonical "what this PR changes" diff and is set by GitHub at PR creation/sync time, so it is **independent of merge strategy** (works for squash, merge-commit, and rebase-and-merge).

The `compare-state-files` action separately gets `curl -fsS` so HTTP errors propagate as step failures with clear `::error::` messages instead of becoming wrong release notes.

## Changes

### `.github/actions/get-pr-info/action.yml` & `README.md`
- New output `base_sha` (= `pr.base.sha`), symmetric to the existing `current_head_sha` (= `pr.head.sha`). One log line added; output table, usage example, and example-output blocks in the README updated to match.

### `.github/workflows/post-merge-flow.yml`
- **Removed** the `Find Previous Release Tag` step entirely.
- **`Compare with Previous Release`** now feeds `compare-state-files` with the two PR SHAs from `pr-info`:
  - `base-source: ${{ steps.pr-info.outputs.base_sha }}`
  - `head-source: ${{ steps.pr-info.outputs.current_head_sha }}`
  - Gate changed from `if: steps.prev-release.outputs.found == 'true'` to `if: steps.validate-config.outputs.should_process == 'true'` — the step now always runs when the pre-check accepted the PR.
- **`Build Release Notes`** simplified: no `PREV_FOUND` env, no "list all modules from current lock.json" fallback. Notes are the compare action's `updated-modules` output (empty when the PR introduces no module changes).

### `.github/actions/compare-state-files/action.yml` & `README.md`
- Both `Get base state from branch` and `Get head state from branch` now wrap the download in `if ! curl -fsS …; then ::error::…; exit 1; fi`. HTTP 4xx/5xx propagate as a step failure with a clear annotation instead of writing the JSON error body to disk and continuing.
- Replaced the buggy `[ $? -ne 0 ] || [ ! -s file ]` check with an explicit "downloaded file is empty" guard after the successful HTTP fetch.
- README: `base-source` / `head-source` descriptions clarify any git ref (branch/tag/SHA) is accepted; corrected the stale `state-file` default (`application-descriptor.json` → `application.lock.json`); Error Handling section rewritten to describe the strict HTTP behaviour.

### `.github/docs/post-merge-flow.md`
- Pre-Check step list rewritten: drops "Find Previous Release Tag" and renames the comparison step to "Compare PR State" with the new SHA-driven description.
- Footer bumped: `1.2 → 1.3 (PR-SHA-driven module diff; strict HTTP in compare-state-files)`.

## Implementation notes

- The `compare-state-files` action's `base-source-type: branch` path passes its input as `ref=…` to the GitHub Contents API, which accepts branch names, tag names, and commit SHAs interchangeably — no change required there, just clearer docs.
- `pr.base.sha` is set at PR creation and updated on head pushes. For auto-generated update PRs that merge quickly it is the merge-base; on stale-base merges it represents the PR's view of "before", which is the correct semantic for "what this release introduces" because intermediate base advances would already have produced their own post-merge runs and release notes.
- For the rare first-ever `application.lock.json` release on an app, `pr.base.sha` predates the lock file and `compare-state-files` will now fail loud with the new HTTP error — operator decides how to issue notes manually. This is intentional per the project's "fail loud over misleading notes" policy (see RANCHER-2961 history).