### PR TITLE
RANCHER-2979. Update workflows to use `actions/create-github-app-token@v3`

### DIFF
--- a/.github/workflows/application-update-flow.yml
+++ b/.github/workflows/application-update-flow.yml
@@ -516,7 +516,7 @@ jobs:
     steps:
       - name: Generate App Token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.EUREKA_CI_APP_ID }}
           private-key: ${{ secrets.EUREKA_CI_APP_KEY }}

--- a/.github/workflows/branch-ruleset-automation-flow.yml
+++ b/.github/workflows/branch-ruleset-automation-flow.yml
@@ -76,7 +76,7 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.EUREKA_CI_APP_ID }}
           private-key: ${{ secrets.EUREKA_CI_APP_KEY }}
@@ -147,7 +147,7 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.EUREKA_CI_APP_ID }}
           private-key: ${{ secrets.EUREKA_CI_APP_KEY }}

--- a/.github/workflows/branch-ruleset-automation.yml
+++ b/.github/workflows/branch-ruleset-automation.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.EUREKA_CI_APP_ID }}
           private-key: ${{ secrets.EUREKA_CI_APP_KEY }}

--- a/.github/workflows/commit-and-push-changes.yml
+++ b/.github/workflows/commit-and-push-changes.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Generate App Token
         id: app-token
         if: inputs.use_github_app == true
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.EUREKA_CI_APP_ID }}
           private-key: ${{ secrets.EUREKA_CI_APP_KEY }}

--- a/.github/workflows/merge-queue-check.yml
+++ b/.github/workflows/merge-queue-check.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.EUREKA_CI_APP_ID }}
           private-key: ${{ secrets.EUREKA_CI_APP_KEY }}
@@ -129,7 +129,7 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.EUREKA_CI_APP_ID }}
           private-key: ${{ secrets.EUREKA_CI_APP_KEY }}
@@ -182,7 +182,7 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.EUREKA_CI_APP_ID }}
           private-key: ${{ secrets.EUREKA_CI_APP_KEY }}

--- a/.github/workflows/post-merge-flow.yml
+++ b/.github/workflows/post-merge-flow.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Generate GitHub App Token
         id: app-token
         if: steps.check-merge.outputs.should_process == 'true'
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.EUREKA_CI_APP_ID }}
           private-key: ${{ secrets.EUREKA_CI_APP_KEY }}
@@ -192,7 +192,7 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.EUREKA_CI_APP_ID }}
           private-key: ${{ secrets.EUREKA_CI_APP_KEY }}
@@ -251,7 +251,7 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.EUREKA_CI_APP_ID }}
           private-key: ${{ secrets.EUREKA_CI_APP_KEY }}
@@ -372,7 +372,7 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.EUREKA_CI_APP_ID }}
           private-key: ${{ secrets.EUREKA_CI_APP_KEY }}

--- a/.github/workflows/post-release-bump-flow.yml
+++ b/.github/workflows/post-release-bump-flow.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
       - name: Generate App Token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.EUREKA_CI_APP_ID }}
           private-key: ${{ secrets.EUREKA_CI_APP_KEY }}

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.EUREKA_CI_APP_ID }}
           private-key: ${{ secrets.EUREKA_CI_APP_KEY }}
@@ -159,7 +159,7 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.EUREKA_CI_APP_ID }}
           private-key: ${{ secrets.EUREKA_CI_APP_KEY }}
@@ -213,7 +213,7 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.EUREKA_CI_APP_ID }}
           private-key: ${{ secrets.EUREKA_CI_APP_KEY }}

--- a/.github/workflows/release-application-version-flow.yml
+++ b/.github/workflows/release-application-version-flow.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.EUREKA_CI_APP_ID }}
           private-key: ${{ secrets.EUREKA_CI_APP_KEY }}
@@ -252,7 +252,7 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.EUREKA_CI_APP_ID }}
           private-key: ${{ secrets.EUREKA_CI_APP_KEY }}


### PR DESCRIPTION
## Summary

- Bump `actions/create-github-app-token@v1` → `@v3` across all reusable workflows in this repo. 9 files, 18 call sites:
  - `application-update-flow.yml` (1)
  - `branch-ruleset-automation-flow.yml` (2)
  - `branch-ruleset-automation.yml` (1)
  - `commit-and-push-changes.yml` (1)
  - `merge-queue-check.yml` (3)
  - `post-merge-flow.yml` (4)
  - `post-release-bump-flow.yml` (1)
  - `pr-check.yml` (3)
  - `release-application-version-flow.yml` (2)
- No surrounding logic touched. The action's input contract (`app-id`, `private-key`, `owner`, `repositories`) and `token` output are unchanged across v1 → v3.

## Motivation

GitHub Actions is deprecating Node.js 20 on runners:
- June 2, 2026 — runners forced to Node.js 24.
- September 16, 2026 — Node.js 20 removed.

`actions/create-github-app-token@v1` runs on Node.js 20 and emits the deprecation warning on every job that mints an App token. With these workflows running continuously across all 40 FOLIO apps (snapshot CI, post-merge, PR checks, branch automation), that's a steady stream of warnings on every CI run. v3.1.1 (April 2026) is the latest stable, Node.js 24-based.

## Dependency

Companion to `folio-org/platform-lsp` PR #124 (https://github.com/folio-org/platform-lsp/pull/124), which performs the same bump for the 2 workflows hosted in that repo. PRs are independent and can land in either order — each retires its own deprecation warnings on its own workflows.

Refs: RANCHER-2979