### PR TITLE
RANCHER-2983. Add dependency-refresh-flow per-app worker

### DIFF
--- a/.github/docs/dependency-refresh-flow.md
+++ b/.github/docs/dependency-refresh-flow.md
@@ -1,0 +1,97 @@
+# Dependency Refresh (Flow)
+
+**Workflow**: `kitfox-github/.github/workflows/dependency-refresh-flow.yml`
+**Type**: `workflow_call` reusable workflow (per-app worker)
+**Called by**: `platform-lsp/.github/workflows/post-release-bump-orchestrator.yml` — the `dependency-refresh` matrix job that runs after `bump`.
+
+Component contract for the per-app template constraint refresh introduced in RANCHER-2983. Bumps `application.template.json` dependency constraints that no longer semver-match the dependee's current snapshot major. Closes the manual gap RANCHER-2982 documented.
+
+## Inputs
+
+| Input | Type | Required | Notes |
+|---|---|---|---|
+| `app_name` | string | yes | Application name (e.g., `app-acquisitions`). Used for artifact names, App-token scoping, and logs. |
+| `repo` | string | yes | Target repository in `org/repo` form (e.g., `folio-org/app-acquisitions`). |
+| `target_branch` | string | no (default `snapshot`) | Branch whose `application.template.json` is refreshed. Default `snapshot` is correct for the standard post-release workflow. |
+| `dry_run` | boolean | no (default `false`) | When true, preflight + stale detection + template rewrite run, but the commit job's push is skipped. |
+
+## Per-App Sequence
+
+1. **Mint App token** — `actions/create-github-app-token@v3` scoped to `repositories: ${{ inputs.app_name }}`. Least-privilege per matrix shard.
+2. **Preflight** — confirms `<target_branch>` and `application.template.json` exist on the target repo. Fast-fails with `target_branch_missing` or `template_missing`.
+3. **Fetch template** — `gh api repos/folio-org/<app>/contents/application.template.json?ref=<target_branch>` → base64-decode → write to a working directory. Validate with `jq -e '.dependencies'`. Fails with `template_parse_failed` if the file is malformed or lacks `.dependencies`.
+4. **Detect stale constraints** — iterate `.dependencies[]`. For each entry:
+   - Skip if the constraint doesn't match `^X.Y.Z[-SNAPSHOT[.N]]` (unrecognized form; log warning).
+   - Fetch the dependee's `pom.xml` from `<target_branch>` via Contents API.
+   - Parse the dependee's `<version>` (using the same `<parent>`-aware awk as `collect-app-version`).
+   - Skip if the dependee's pom is unreadable or unparseable (log warning).
+   - **Stale test**: constraint's major ≠ dep's current major → mark stale; new constraint = `^<dep-current-major>.<dep-current-minor>.0-SNAPSHOT` (narrow-minor).
+5. **Idempotency gate** — if no entries are stale, the run resolves to `status=skipped`, `skipped_reason=no_stale_deps`, no commit.
+6. **Rewrite template** — single `jq` pass applies all stale updates. Verifies a real diff was produced (defensive check; `template_edit_no_op` otherwise).
+7. **Stage + upload artifact** — the modified `application.template.json` is uploaded as artifact `${app_name}-dependency-refresh-files`.
+8. **Commit & push** — `commit-and-push-changes.yml@master` is called with `branch: <target_branch>`, `use_github_app: true`. The commit message lists each refreshed entry in the form `<dep>: <old> → <new>`.
+9. **Result artifact** — `<app_name>-deprefresh.json` (artifact name `deprefresh-<app_name>`) emitted for orchestrator aggregation.
+
+## Result Artifact
+
+`deprefresh-<app_name>`:
+
+```json
+{
+  "application": "app-bulk-edit",
+  "phase": "deprefresh",
+  "status": "success | skipped | failed",
+  "target_branch": "snapshot",
+  "refreshed_count": 1,
+  "refreshed_constraints": [
+    { "dep": "app-fqm", "old": "^1.2.0-SNAPSHOT", "new": "^2.1.0-SNAPSHOT" }
+  ],
+  "commit_sha": "abc1234",
+  "failure_reason": "",
+  "skipped_reason": "",
+  "dry_run": false
+}
+```
+
+Uploaded with `actions/upload-artifact@v4` and name `deprefresh-<app_name>`. The orchestrator's `collect-results` job downloads with `pattern: "deprefresh-*"`, `merge-multiple: true`. The artifact name space is intentionally distinct from the bump phase's `result-*` artifacts so both can coexist in `collect-results`.
+
+## Refresh Policy
+
+**Stale-only**. A constraint is touched only when its major no longer semver-matches the dependee's current snapshot major. Constraints that still match (within-major bumps to the dependee, or no change at all) are left untouched.
+
+The new constraint uses **narrow-minor form**: `^<dep-current-major>.<dep-current-minor>.0-SNAPSHOT`. The `^` carat semver covers all of the dependee's current minor lineage and onwards within the same major, so re-running won't trigger another refresh until the dependee crosses major again.
+
+## Failure Reason Codes
+
+| Reason | Meaning | Remediation |
+|---|---|---|
+| `target_branch_missing` | `<target_branch>` doesn't exist on the target repo. | Confirm the post-release bump phase ran for this app, or drop the app from scope. |
+| `template_missing` | `application.template.json` doesn't exist on `<target_branch>`. | Investigate the repo's state — every FOLIO app should carry this file. |
+| `template_parse_failed` | The fetched `application.template.json` isn't valid JSON or lacks `.dependencies`. | Inspect the file on the target branch. |
+| `dep_version_read_failed` | The detect-stale step failed entirely. Likely a token scope or rate-limit issue. | Check the step logs for the per-dep warnings. |
+| `template_edit_no_op` | The `jq` rewrite produced no diff despite stale entries being detected. Defensive — shouldn't normally trigger. | Inspect the template structure; possible non-standard formatting. |
+| `commit_failed` | `commit-and-push-changes.yml` failed to push. | Check the push step logs; verify the App is in the target branch's ruleset `bypass_actors`. |
+
+## Skipped Reason Codes
+
+| Reason | Meaning |
+|---|---|
+| `no_stale_deps` | Every dependency constraint already semver-matches the dependee's current major. No commit needed. |
+
+## Authentication
+
+- One GitHub App token is minted **per matrix shard**, scoped to a single target repository via `repositories: ${{ inputs.app_name }}`. Token leak in one shard's logs cannot compromise other repos.
+- Auth requires `vars.EUREKA_CI_APP_ID` and `secrets.EUREKA_CI_APP_KEY`.
+- For the push to succeed, the App identity must be in the target branch ruleset's `bypass_actors` (already configured by every app's `update-config.yml`).
+
+## Out-of-Scope Behavior
+
+- **Does not touch `<app_name>.template.json`** — only `application.template.json`. The two files coexist in each repo but the former is not maintained in lockstep; editing it creates noise.
+- **Does not refresh module/UI module versions** — those are handled by `application-update-flow.yml` on a different cadence.
+- **Does not narrow constraints that still semver-match** — locked stale-only policy. If a dependee bumped within-major (e.g., 2.1.0 → 2.2.0), a `^2.1.0-SNAPSHOT` or `^2.0.0-SNAPSHOT` constraint stays untouched.
+
+## Related Workflows
+
+- `post-release-bump-flow.yml` — the bump phase that runs immediately before this flow in the orchestrator. See [`post-release-bump-flow.md`](post-release-bump-flow.md).
+- `commit-and-push-changes.yml` — reused for the commit step; see [`commit-and-push-changes.md`](commit-and-push-changes.md).
+- `collect-app-version` action — the same `gh api + awk` read pattern is used inline here for each dependee; see [`actions/collect-app-version/README.md`](../actions/collect-app-version/README.md).

--- a/.github/docs/post-release-bump-flow.md
+++ b/.github/docs/post-release-bump-flow.md
@@ -78,5 +78,6 @@ Uploaded with `actions/upload-artifact@v4` and name `result-<app_name>`. The orc
 ## Related Workflows
 
 - `commit-and-push-changes.yml` — reused for the commit step; see [`commit-and-push-changes.md`](commit-and-push-changes.md).
+- `dependency-refresh-flow.yml` — the dep-refresh phase that follows this flow in the orchestrator. Refreshes `application.template.json` constraints when a dependee crossed a major boundary during the bump. See [`dependency-refresh-flow.md`](dependency-refresh-flow.md).
 - `release-preparation-flow.yml` — the per-app worker for release branch creation, called by `release-preparation-orchestrator.yml`. This flow runs *after* release-preparation completes.
 - `application-update-flow.yml` — the per-app worker for routine snapshot module-version updates. Different concern: it bumps module versions in `application.template.json`, not the project version in `pom.xml`.

--- a/.github/workflows/dependency-refresh-flow.yml
+++ b/.github/workflows/dependency-refresh-flow.yml
@@ -1,0 +1,383 @@
+name: Dependency Refresh (Flow)
+
+on:
+  workflow_call:
+    inputs:
+      app_name:
+        description: 'Application name (e.g., app-acquisitions)'
+        required: true
+        type: string
+      repo:
+        description: 'Application repository (org/repo)'
+        required: true
+        type: string
+      target_branch:
+        description: 'Branch whose application.template.json should be refreshed. Default: snapshot.'
+        required: false
+        type: string
+        default: 'snapshot'
+      dry_run:
+        description: 'Perform dry run without committing'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+jobs:
+  prepare-refresh:
+    name: Prepare Refresh
+    runs-on: ubuntu-latest
+    outputs:
+      status: ${{ steps.finalize.outputs.status }}
+      has_changes: ${{ steps.finalize.outputs.has_changes }}
+      refreshed_count: ${{ steps.finalize.outputs.refreshed_count }}
+      refreshed_constraints: ${{ steps.finalize.outputs.refreshed_constraints }}
+      refresh_summary: ${{ steps.finalize.outputs.refresh_summary }}
+      failure_reason: ${{ steps.finalize.outputs.failure_reason }}
+      skipped_reason: ${{ steps.finalize.outputs.skipped_reason }}
+    steps:
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.EUREKA_CI_APP_ID }}
+          private-key: ${{ secrets.EUREKA_CI_APP_KEY }}
+          owner: folio-org
+          repositories: ${{ inputs.app_name }}
+
+      - name: Preflight - Verify Branch and Template Exist
+        id: preflight
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP: ${{ inputs.app_name }}
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+        run: |
+          set -eo pipefail
+
+          if ! gh api "repos/folio-org/$APP/branches/$TARGET_BRANCH" --silent 2>/dev/null; then
+            echo "::error::Target branch '$TARGET_BRANCH' not found on folio-org/$APP"
+            echo "failure_reason=target_branch_missing" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+          if ! gh api "repos/folio-org/$APP/contents/application.template.json?ref=$TARGET_BRANCH" --silent 2>/dev/null; then
+            echo "::error::application.template.json not found on folio-org/$APP@$TARGET_BRANCH"
+            echo "failure_reason=template_missing" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+          echo "::notice::Branch and template confirmed on folio-org/$APP@$TARGET_BRANCH"
+
+      - name: Fetch Template
+        id: fetch-template
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP: ${{ inputs.app_name }}
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+        run: |
+          set -eo pipefail
+
+          mkdir -p /tmp/work
+          if ! gh api "repos/folio-org/$APP/contents/application.template.json?ref=$TARGET_BRANCH" --jq '.content' 2>/dev/null | base64 -d > /tmp/work/application.template.json; then
+            echo "::error::Failed to fetch application.template.json from $APP@$TARGET_BRANCH"
+            echo "failure_reason=template_parse_failed" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+          if ! jq -e '.dependencies' /tmp/work/application.template.json >/dev/null 2>&1; then
+            echo "::error::application.template.json on $APP@$TARGET_BRANCH is not valid JSON or lacks .dependencies"
+            echo "failure_reason=template_parse_failed" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+          dep_count=$(jq '.dependencies | length' /tmp/work/application.template.json)
+          echo "::notice::Template parsed; $dep_count dependency entries"
+          cp /tmp/work/application.template.json /tmp/work/application.template.json.orig
+
+      - name: Detect Stale Constraints
+        id: detect-stale
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+        run: |
+          set -eo pipefail
+
+          refreshed='[]'
+          summary=''
+
+          while IFS=$'\t' read -r dep_name dep_constraint; do
+            [ -z "$dep_name" ] && continue
+
+            if [[ ! "$dep_name" =~ ^app- ]]; then
+              echo "::notice::Skipping non-app dependency: $dep_name"
+              continue
+            fi
+
+            if [[ ! "$dep_constraint" =~ ^\^([0-9]+)\.([0-9]+)\.([0-9]+)(-SNAPSHOT(\.[0-9]+)?)?$ ]]; then
+              echo "::warning::$dep_name: unrecognized constraint format '$dep_constraint' — leaving untouched"
+              continue
+            fi
+            constraint_major="${BASH_REMATCH[1]}"
+
+            if ! dep_pom=$(gh api "repos/folio-org/$dep_name/contents/pom.xml?ref=$TARGET_BRANCH" --jq '.content' 2>/dev/null); then
+              echo "::warning::$dep_name: could not fetch pom.xml from $TARGET_BRANCH — leaving constraint untouched"
+              continue
+            fi
+
+            dep_version=$(printf '%s' "$dep_pom" | base64 -d | awk '
+              /<parent>/    { in_parent=1 }
+              /<\/parent>/  { in_parent=0; next }
+              in_parent     { next }
+              /<version>/   { if (match($0, /<version>[^<]+<\/version>/)) { print substr($0, RSTART+9, RLENGTH-19); exit } }
+            ')
+
+            if [[ ! "$dep_version" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(-SNAPSHOT(\.[0-9]+)?)?$ ]]; then
+              echo "::warning::$dep_name: pom version '$dep_version' is not parseable SemVer — leaving constraint untouched"
+              continue
+            fi
+            dep_current_major="${BASH_REMATCH[1]}"
+            dep_current_minor="${BASH_REMATCH[2]}"
+
+            if [ "$constraint_major" = "$dep_current_major" ]; then
+              continue
+            fi
+
+            new_constraint="^${dep_current_major}.${dep_current_minor}.0-SNAPSHOT"
+            echo "::notice::$dep_name: STALE — $dep_constraint → $new_constraint"
+
+            entry=$(jq -nc --arg dep "$dep_name" --arg old "$dep_constraint" --arg new "$new_constraint" \
+              '{dep: $dep, old: $old, new: $new}')
+            refreshed=$(jq -c --argjson e "$entry" '. + [$e]' <<<"$refreshed")
+            summary="${summary}${dep_name}: ${dep_constraint} → ${new_constraint}"$'\n'
+
+          done < <(jq -r '.dependencies[] | "\(.name)\t\(.version)"' /tmp/work/application.template.json)
+
+          refreshed_count=$(jq 'length' <<<"$refreshed")
+          echo "::notice::Detected $refreshed_count stale dependency constraint(s)"
+
+          echo "refreshed_count=$refreshed_count" >> "$GITHUB_OUTPUT"
+          {
+            echo "refreshed<<EOF"
+            printf '%s' "$refreshed"
+            echo
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "summary<<EOF"
+            printf '%s' "$summary"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Rewrite Template
+        id: rewrite
+        if: steps.detect-stale.outputs.refreshed_count != '0'
+        env:
+          REFRESHED: ${{ steps.detect-stale.outputs.refreshed }}
+        run: |
+          set -eo pipefail
+
+          jq --argjson updates "$REFRESHED" '
+            .dependencies |= map(
+              . as $dep
+              | ($updates[] | select(.dep == $dep.name)) as $u
+              | if $u then .version = $u.new else . end
+            )
+          ' /tmp/work/application.template.json.orig > /tmp/work/application.template.json
+
+          if diff -q /tmp/work/application.template.json.orig /tmp/work/application.template.json >/dev/null 2>&1; then
+            echo "::error::jq rewrite produced no diff despite stale entries — defensive failure"
+            echo "failure_reason=template_edit_no_op" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+          echo "::group::Template diff"
+          diff -u /tmp/work/application.template.json.orig /tmp/work/application.template.json || true
+          echo "::endgroup::"
+
+      - name: Stage Artifact
+        if: steps.detect-stale.outputs.refreshed_count != '0' && steps.rewrite.outcome == 'success'
+        run: |
+          set -eo pipefail
+          mkdir -p /tmp/artifact
+          cp /tmp/work/application.template.json /tmp/artifact/application.template.json
+
+      - name: Upload Template Artifact
+        if: steps.detect-stale.outputs.refreshed_count != '0' && steps.rewrite.outcome == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.app_name }}-dependency-refresh-files
+          overwrite: true
+          path: /tmp/artifact/
+          retention-days: 1
+
+      - name: Finalize Outputs
+        id: finalize
+        if: always()
+        env:
+          PREFLIGHT_FAILURE: ${{ steps.preflight.outputs.failure_reason }}
+          FETCH_FAILURE: ${{ steps.fetch-template.outputs.failure_reason }}
+          REWRITE_FAILURE: ${{ steps.rewrite.outputs.failure_reason }}
+          PREFLIGHT_RESULT: ${{ steps.preflight.outcome }}
+          FETCH_RESULT: ${{ steps.fetch-template.outcome }}
+          DETECT_RESULT: ${{ steps.detect-stale.outcome }}
+          REWRITE_RESULT: ${{ steps.rewrite.outcome }}
+          REFRESHED_COUNT: ${{ steps.detect-stale.outputs.refreshed_count }}
+          REFRESHED: ${{ steps.detect-stale.outputs.refreshed }}
+          SUMMARY: ${{ steps.detect-stale.outputs.summary }}
+        run: |
+          set -eo pipefail
+
+          failure_reason=""
+          if [ "$PREFLIGHT_RESULT" = "failure" ]; then
+            failure_reason="${PREFLIGHT_FAILURE:-preflight_failed}"
+          elif [ "$FETCH_RESULT" = "failure" ]; then
+            failure_reason="${FETCH_FAILURE:-template_parse_failed}"
+          elif [ "$DETECT_RESULT" = "failure" ]; then
+            failure_reason="dep_version_read_failed"
+          elif [ "$REWRITE_RESULT" = "failure" ]; then
+            failure_reason="${REWRITE_FAILURE:-template_edit_no_op}"
+          fi
+
+          if [ -n "$failure_reason" ]; then
+            status="failed"
+            has_changes="false"
+            skipped_reason=""
+          elif [ "${REFRESHED_COUNT:-0}" = "0" ]; then
+            status="skipped"
+            has_changes="false"
+            skipped_reason="no_stale_deps"
+          else
+            status="prepared"
+            has_changes="true"
+            skipped_reason=""
+          fi
+
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          echo "has_changes=$has_changes" >> "$GITHUB_OUTPUT"
+          echo "refreshed_count=${REFRESHED_COUNT:-0}" >> "$GITHUB_OUTPUT"
+          {
+            echo "refreshed_constraints<<EOF"
+            printf '%s' "${REFRESHED:-[]}"
+            echo
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "refresh_summary<<EOF"
+            printf '%s' "$SUMMARY"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "failure_reason=$failure_reason" >> "$GITHUB_OUTPUT"
+          echo "skipped_reason=$skipped_reason" >> "$GITHUB_OUTPUT"
+
+          echo "::notice::Final status: $status (has_changes=$has_changes, refreshed_count=${REFRESHED_COUNT:-0}, failure_reason='$failure_reason', skipped_reason='$skipped_reason')"
+
+  commit-refresh:
+    name: Commit Refreshed Template
+    needs: prepare-refresh
+    if: needs.prepare-refresh.outputs.has_changes == 'true'
+    uses: folio-org/kitfox-github/.github/workflows/commit-and-push-changes.yml@master
+    with:
+      repo: ${{ inputs.repo }}
+      branch: ${{ inputs.target_branch }}
+      artifact_name: ${{ inputs.app_name }}-dependency-refresh-files
+      use_github_app: true
+      commit_message: |
+        Refresh template dependency constraints on ${{ inputs.target_branch }}
+
+        Auto-generated by post-release-bump orchestrator (dependency-refresh phase).
+        Refreshed entries:
+        ${{ needs.prepare-refresh.outputs.refresh_summary }}
+
+        Refs: RANCHER-2983
+      dry_run: ${{ inputs.dry_run }}
+    secrets: inherit
+
+  upload_results:
+    name: Upload Results
+    runs-on: ubuntu-latest
+    needs: [prepare-refresh, commit-refresh]
+    if: always()
+    steps:
+      - name: Prepare Result Artifact
+        env:
+          APP_NAME: ${{ inputs.app_name }}
+          PREPARE_RESULT: ${{ needs.prepare-refresh.result }}
+          COMMIT_RESULT: ${{ needs.commit-refresh.result }}
+          PREPARE_STATUS: ${{ needs.prepare-refresh.outputs.status }}
+          HAS_CHANGES: ${{ needs.prepare-refresh.outputs.has_changes }}
+          PREPARE_FAILURE_REASON: ${{ needs.prepare-refresh.outputs.failure_reason }}
+          SKIPPED_REASON: ${{ needs.prepare-refresh.outputs.skipped_reason }}
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+          REFRESHED_COUNT: ${{ needs.prepare-refresh.outputs.refreshed_count }}
+          REFRESHED: ${{ needs.prepare-refresh.outputs.refreshed_constraints }}
+          COMMIT_SHA: ${{ needs.commit-refresh.outputs.commit_sha }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -eo pipefail
+
+          mkdir -p /tmp/results
+
+          if [ "$PREPARE_RESULT" != "success" ]; then
+            status="failed"
+            failure_reason="${PREPARE_FAILURE_REASON:-prepare_job_${PREPARE_RESULT}}"
+            skipped_reason=""
+          elif [ "$PREPARE_STATUS" = "skipped" ]; then
+            status="skipped"
+            failure_reason=""
+            skipped_reason="$SKIPPED_REASON"
+          elif [ "$PREPARE_STATUS" = "failed" ]; then
+            status="failed"
+            failure_reason="$PREPARE_FAILURE_REASON"
+            skipped_reason=""
+          else
+            if [ "$DRY_RUN" = "true" ]; then
+              status="success"
+              failure_reason=""
+              skipped_reason=""
+            elif [ "$COMMIT_RESULT" = "success" ]; then
+              status="success"
+              failure_reason=""
+              skipped_reason=""
+            else
+              status="failed"
+              failure_reason="commit_failed"
+              skipped_reason=""
+            fi
+          fi
+
+          jq -n \
+            --arg application "$APP_NAME" \
+            --arg phase "deprefresh" \
+            --arg status "$status" \
+            --arg target_branch "$TARGET_BRANCH" \
+            --arg refreshed_count "${REFRESHED_COUNT:-0}" \
+            --argjson refreshed_constraints "${REFRESHED:-[]}" \
+            --arg commit_sha "$COMMIT_SHA" \
+            --arg failure_reason "$failure_reason" \
+            --arg skipped_reason "$skipped_reason" \
+            --argjson dry_run "${DRY_RUN:-false}" \
+            '{
+              application: $application,
+              phase: $phase,
+              status: $status,
+              target_branch: $target_branch,
+              refreshed_count: ($refreshed_count | tonumber),
+              refreshed_constraints: $refreshed_constraints,
+              commit_sha: $commit_sha,
+              failure_reason: $failure_reason,
+              skipped_reason: $skipped_reason,
+              dry_run: $dry_run
+            }' > "/tmp/results/$APP_NAME-deprefresh.json"
+
+          echo "::notice::Result for $APP_NAME (deprefresh):"
+          cat "/tmp/results/$APP_NAME-deprefresh.json"
+
+      - name: Upload Application Result
+        uses: actions/upload-artifact@v4
+        with:
+          name: deprefresh-${{ inputs.app_name }}
+          overwrite: true
+          path: /tmp/results/${{ inputs.app_name }}-deprefresh.json
+          retention-days: 1


### PR DESCRIPTION
## Summary

- Add `dependency-refresh-flow.yml` — `workflow_call` reusable per-app worker that refreshes `application.template.json` dependency constraints on a target branch (default `snapshot`).
- For each dependency: fetch the dependee's current snapshot version via `gh api`/awk (same read pattern as `collect-app-version`), compare to the existing constraint's major. If the major no longer semver-matches, rewrite the constraint to `^<dep-current-major>.<dep-current-minor>.0-SNAPSHOT` (narrow-minor) via `jq`.
- **Stale-only**: constraints that still semver-match are left untouched — no churn on within-major bumps.
- **Idempotent**: re-runs with no stale constraints resolve to `status=skipped`, `skipped_reason=no_stale_deps`, no commit.
- Edits only `application.template.json` — never `<app_name>.template.json` (per RANCHER-2982 lesson).
- Commit + push via the existing `commit-and-push-changes.yml`. Result artifact emitted as `deprefresh-<app>` for orchestrator aggregation.
- Add `.github/docs/dependency-refresh-flow.md` — component reference: inputs, per-app sequence, failure/skipped codes, result artifact schema, refresh policy, auth scoping.
- Cross-link from `post-release-bump-flow.md` Related Workflows.

## Motivation

RANCHER-2951's post-release bump orchestrator updates each app's `pom.xml` project version after a release branch is cut, but it doesn't touch dependency constraints in `application.template.json`. When a dependee crosses a major boundary during the bump (e.g., `app-acquisitions` 1.X → 2.1.0-SNAPSHOT in Trillium), dependents' `^1.X.X-SNAPSHOT` constraints no longer semver-match and have to be refreshed by hand — RANCHER-2982 documented that manual cleanup across 9 repos. This worker mechanizes the constraint refresh so it doesn't repeat next release cycle.

## Dependency

Companion to `folio-org/platform-lsp` PR (to be opened on the RANCHER-2983 branch), which adds a `dependency-refresh` matrix job to `post-release-bump-orchestrator.yml` calling this flow per app. PRs can merge in either order; the system is only operational once both are on `master`.

Builds on:
- RANCHER-2977 — `collect-app-version` refactor to a non-Maven read (this flow uses the same `gh api`+awk read pattern inline for each dependee).
- RANCHER-2982 — manual cleanup that validated the refresh approach (stale-only policy, narrow-minor constraint form, `application.template.json` only).

Refs: RANCHER-2983